### PR TITLE
Fix banks_client_benchmark

### DIFF
--- a/benches/banks_client_comparison.rs
+++ b/benches/banks_client_comparison.rs
@@ -24,7 +24,7 @@ fn add_program(bytes: &[u8], program_id: Pubkey, pt: &mut solana_program_test::P
         Account {
             lamports: Rent::default().minimum_balance(bytes.len()).max(1),
             data: bytes.to_vec(),
-            owner: solana_sdk::bpf_loader_upgradeable::id(),
+            owner: solana_sdk::bpf_loader::id(),
             executable: true,
             rent_epoch: 0,
         },


### PR DESCRIPTION
The BanksClient benchmark needs bpf_loader instead of bpf_loader_upgradeable. Not sure why but it's not our code so don't care lol