### PR TITLE
Handle base fees and include failed transactions in transaction history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,6 +1418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1437,16 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -2166,6 +2185,7 @@ dependencies = [
  "criterion",
  "indexmap 2.2.6",
  "itertools 0.12.1",
+ "log",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
@@ -2176,6 +2196,7 @@ dependencies = [
  "solana-sdk",
  "solana-system-program",
  "spl-token 3.5.0",
+ "test-log",
  "thiserror",
  "tokio",
 ]
@@ -2192,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lru"
@@ -4018,7 +4039,7 @@ version = "1.18.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5559aeadd3adc219fa7169e96a8c5dda618c7f06985f91f2a5f55b9814c7a2"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.3",
  "lazy_static",
  "log",
 ]
@@ -5259,6 +5280,27 @@ dependencies = [
  "quote",
  "syn 2.0.48",
  "test-case-core",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b319995299c65d522680decf80f2c108d85b861d81dfe340a10d16cee29d9e6"
+dependencies = [
+ "env_logger 0.11.3",
+ "test-log-macros",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,14 @@ solana-loader-v4-program = "~1.18"
 bincode = "1.3"
 indexmap = "2.2.6"
 solana-address-lookup-table-program = "1.18.8"
+log = "0.4.21"
 
 [dev-dependencies]
 spl-token = "3.5.0"
 solana-program-test = "~1.18"
 criterion = "0.5"
 tokio = "1.35"
+test-log = "0.2.15"
 
 [features]
 internal-test = []

--- a/src/accounts_db.rs
+++ b/src/accounts_db.rs
@@ -21,10 +21,13 @@ use solana_program_runtime::{
     sysvar_cache::SysvarCache,
 };
 use solana_sdk::{
-    account::{AccountSharedData, ReadableAccount},
+    account::{AccountSharedData, ReadableAccount, WritableAccount},
     account_utils::StateMut,
+    nonce,
     pubkey::Pubkey,
+    transaction::TransactionError,
 };
+use solana_system_program::{get_system_account_kind, SystemAccountKind};
 use std::{collections::HashMap, sync::Arc};
 
 use crate::types::InvalidSysvarDataError;
@@ -287,6 +290,32 @@ impl AccountsDb {
             })
         } else {
             Err(AddressLookupError::InvalidAccountOwner)
+        }
+    }
+
+    fn withdraw(&mut self, pubkey: &Pubkey, lamports: u64) -> solana_sdk::transaction::Result<()> {
+        match self.inner.get_mut(pubkey) {
+            Some(account) => {
+                let min_balance = match get_system_account_kind(&account) {
+                    Some(SystemAccountKind::Nonce) => self
+                        .sysvar_cache
+                        .get_rent()
+                        .unwrap()
+                        .minimum_balance(nonce::State::size()),
+                    _ => 0,
+                };
+
+                lamports
+                    .checked_add(min_balance)
+                    .filter(|required_balance| *required_balance <= account.lamports())
+                    .ok_or(TransactionError::InsufficientFundsForFee)?;
+                account
+                    .checked_sub_lamports(lamports)
+                    .map_err(|_| TransactionError::InsufficientFundsForFee)?;
+
+                Ok(())
+            }
+            None => Err(TransactionError::AccountNotFound),
         }
     }
 }

--- a/src/accounts_db.rs
+++ b/src/accounts_db.rs
@@ -293,10 +293,14 @@ impl AccountsDb {
         }
     }
 
-    fn withdraw(&mut self, pubkey: &Pubkey, lamports: u64) -> solana_sdk::transaction::Result<()> {
+    pub(crate) fn withdraw(
+        &mut self,
+        pubkey: &Pubkey,
+        lamports: u64,
+    ) -> solana_sdk::transaction::Result<()> {
         match self.inner.get_mut(pubkey) {
             Some(account) => {
-                let min_balance = match get_system_account_kind(&account) {
+                let min_balance = match get_system_account_kind(account) {
                     Some(SystemAccountKind::Nonce) => self
                         .sysvar_cache
                         .get_rent()

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,8 +1,8 @@
-use crate::types::TransactionMetadata;
+use crate::types::TransactionResult;
 use indexmap::IndexMap;
 use solana_sdk::signature::Signature;
 
-pub struct TransactionHistory(IndexMap<Signature, TransactionMetadata>);
+pub struct TransactionHistory(IndexMap<Signature, TransactionResult>);
 
 impl TransactionHistory {
     pub fn new() -> Self {
@@ -17,17 +17,17 @@ impl TransactionHistory {
         }
     }
 
-    pub fn get_transaction(&self, signature: &Signature) -> Option<&TransactionMetadata> {
+    pub fn get_transaction(&self, signature: &Signature) -> Option<&TransactionResult> {
         self.0.get(signature)
     }
 
-    pub fn add_new_transaction(&mut self, signature: Signature, meta: TransactionMetadata) {
+    pub fn add_new_transaction(&mut self, signature: Signature, result: TransactionResult) {
         let capacity = self.0.capacity();
         if capacity != 0 {
             if self.0.len() == capacity {
                 self.0.shift_remove_index(0);
             }
-            self.0.insert(signature, meta);
+            self.0.insert(signature, result);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,6 +656,7 @@ impl LiteSVM {
                 post_accounts,
                 compute_units_consumed,
                 return_data,
+                included: true,
             }
         } else {
             ExecutionResult {
@@ -683,6 +684,7 @@ impl LiteSVM {
             signature,
             compute_units_consumed,
             return_data,
+            included,
         } = if self.sigverify {
             self.execute_transaction(vtx)
         } else {
@@ -695,12 +697,14 @@ impl LiteSVM {
             return_data,
             signature,
         };
+        if included {
+            self.history
+                .add_new_transaction(meta.signature, meta.clone());
+        }
 
         if let Err(tx_err) = tx_result {
             TransactionResult::Err(FailedTransactionMetadata { err: tx_err, meta })
         } else {
-            self.history
-                .add_new_transaction(meta.signature, meta.clone());
             self.accounts
                 .sync_accounts(post_accounts)
                 .expect("It shouldn't be possible to write invalid sysvars in send_transaction.");
@@ -716,6 +720,7 @@ impl LiteSVM {
             signature,
             compute_units_consumed,
             return_data,
+            ..
         } = if self.sigverify {
             self.execute_transaction(tx)
         } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,11 +24,13 @@ pub struct FailedTransactionMetadata {
 pub type TransactionResult = std::result::Result<TransactionMetadata, FailedTransactionMetadata>;
 
 pub(crate) struct ExecutionResult {
-    pub post_accounts: Vec<(Pubkey, AccountSharedData)>,
-    pub tx_result: Result<()>,
-    pub signature: Signature,
-    pub compute_units_consumed: u64,
-    pub return_data: TransactionReturnData,
+    pub(crate) post_accounts: Vec<(Pubkey, AccountSharedData)>,
+    pub(crate) tx_result: Result<()>,
+    pub(crate) signature: Signature,
+    pub(crate) compute_units_consumed: u64,
+    pub(crate) return_data: TransactionReturnData,
+    /// Whether the transaction can be included in a block
+    pub(crate) included: bool,
 }
 
 impl Default for ExecutionResult {
@@ -39,6 +41,7 @@ impl Default for ExecutionResult {
             signature: Default::default(),
             compute_units_consumed: Default::default(),
             return_data: Default::default(),
+            included: false,
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,7 +15,7 @@ pub struct TransactionMetadata {
     pub return_data: TransactionReturnData,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FailedTransactionMetadata {
     pub err: TransactionError,
     pub meta: TransactionMetadata,

--- a/test_programs/Cargo.lock
+++ b/test_programs/Cargo.lock
@@ -579,6 +579,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "failure"
+version = "0.1.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
 name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/test_programs/Cargo.toml
+++ b/test_programs/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["counter"]
+members = ["counter", "failure"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/test_programs/failure/Cargo.toml
+++ b/test_programs/failure/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "failure"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+solana-program.workspace = true

--- a/test_programs/failure/src/lib.rs
+++ b/test_programs/failure/src/lib.rs
@@ -1,0 +1,19 @@
+// This program just returns an error.
+
+use solana_program::entrypoint;
+use solana_program::{
+    account_info::AccountInfo, declare_id, entrypoint::ProgramResult, program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+declare_id!("HvrRMSshMx3itvsyWDnWg2E3cy5h57iMaR7oVxSZJDSA");
+
+entrypoint!(process_instruction);
+
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    Err(ProgramError::Custom(0))
+}

--- a/tests/compute_budget.rs
+++ b/tests/compute_budget.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
     transaction::{Transaction, TransactionError},
 };
 
-#[test]
+#[test_log::test]
 fn test_set_compute_budget() {
     // see that the tx fails if we set a tiny limit
     let from_keypair = Keypair::new();
@@ -18,8 +18,9 @@ fn test_set_compute_budget() {
     let to = Pubkey::new_unique();
 
     let mut svm = LiteSVM::new();
+    let tx_fee = 5000;
 
-    svm.airdrop(&from, 100).unwrap();
+    svm.airdrop(&from, tx_fee + 100).unwrap();
     svm.set_compute_budget(ComputeBudget {
         compute_unit_limit: 10,
         ..Default::default()
@@ -46,8 +47,9 @@ fn test_set_compute_unit_limit() {
     let to = Pubkey::new_unique();
 
     let mut svm = LiteSVM::new();
+    let tx_fee = 5000;
 
-    svm.airdrop(&from, 100).unwrap();
+    svm.airdrop(&from, tx_fee + 100).unwrap();
 
     let instruction = transfer(&from, &to, 64);
     let tx = Transaction::new(

--- a/tests/fees.rs
+++ b/tests/fees.rs
@@ -1,0 +1,72 @@
+use std::path::PathBuf;
+
+use litesvm::LiteSVM;
+use solana_program::{message::Message, pubkey::Pubkey, system_instruction::transfer};
+use solana_sdk::{
+    instruction::{Instruction, InstructionError},
+    pubkey,
+    rent::Rent,
+    signature::Keypair,
+    signer::Signer,
+    transaction::{Transaction, TransactionError},
+};
+
+#[test_log::test]
+fn test_insufficient_funds_for_rent() {
+    let from_keypair = Keypair::new();
+    let from = from_keypair.pubkey();
+    let to = Pubkey::new_unique();
+
+    let mut svm = LiteSVM::new();
+
+    svm.airdrop(&from, svm.get_sysvar::<Rent>().minimum_balance(0))
+        .unwrap();
+    let instruction = transfer(&from, &to, 1);
+    let tx = Transaction::new(
+        &[&from_keypair],
+        Message::new(&[instruction], Some(&from)),
+        svm.latest_blockhash(),
+    );
+    let tx_res = svm.send_transaction(tx);
+
+    assert_eq!(
+        tx_res.unwrap_err().err,
+        TransactionError::InsufficientFundsForRent { account_index: 0 }
+    );
+}
+
+fn read_failure_program() -> Vec<u8> {
+    let mut so_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    so_path.push("test_programs/target/deploy/failure.so");
+    std::fs::read(so_path).unwrap()
+}
+
+#[test_log::test]
+fn test_fees_failed_transaction() {
+    let from_keypair = Keypair::new();
+    let from = from_keypair.pubkey();
+
+    let mut svm = LiteSVM::new();
+    let program_id = pubkey!("HvrRMSshMx3itvsyWDnWg2E3cy5h57iMaR7oVxSZJDSA");
+    svm.add_program(program_id, &read_failure_program());
+    let initial_balance = 1_000_000_000;
+    svm.airdrop(&from, initial_balance).unwrap();
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![],
+        data: vec![],
+    };
+    let tx = Transaction::new(
+        &[&from_keypair],
+        Message::new(&[instruction], Some(&from)),
+        svm.latest_blockhash(),
+    );
+    let tx_res = svm.send_transaction(tx);
+
+    assert_eq!(
+        tx_res.unwrap_err().err,
+        TransactionError::InstructionError(0, InstructionError::Custom(0))
+    );
+    let balance_after = svm.get_balance(&from).unwrap();
+    assert_eq!(initial_balance - balance_after, 5000);
+}

--- a/tests/fees.rs
+++ b/tests/fees.rs
@@ -27,12 +27,14 @@ fn test_insufficient_funds_for_rent() {
         Message::new(&[instruction], Some(&from)),
         svm.latest_blockhash(),
     );
+    let signature = tx.signatures[0];
     let tx_res = svm.send_transaction(tx);
 
     assert_eq!(
         tx_res.unwrap_err().err,
         TransactionError::InsufficientFundsForRent { account_index: 0 }
     );
+    assert!(svm.get_transaction(&signature).is_none());
 }
 
 fn read_failure_program() -> Vec<u8> {
@@ -61,6 +63,7 @@ fn test_fees_failed_transaction() {
         Message::new(&[instruction], Some(&from)),
         svm.latest_blockhash(),
     );
+    let signature = tx.signatures[0];
     let tx_res = svm.send_transaction(tx);
 
     assert_eq!(
@@ -68,5 +71,7 @@ fn test_fees_failed_transaction() {
         TransactionError::InstructionError(0, InstructionError::Custom(0))
     );
     let balance_after = svm.get_balance(&from).unwrap();
-    assert_eq!(initial_balance - balance_after, 5000);
+    let expected_fee = 5000;
+    assert_eq!(initial_balance - balance_after, expected_fee);
+    assert!(svm.get_transaction(&signature).unwrap().is_err());
 }

--- a/tests/spl.rs
+++ b/tests/spl.rs
@@ -1,7 +1,6 @@
 use litesvm::LiteSVM;
 use solana_sdk::{
-    program_pack::Pack, signature::Keypair, signer::Signer, system_instruction,
-    transaction::Transaction,
+    program_pack::Pack, rent::Rent, signature::Keypair, signer::Signer, system_instruction, transaction::Transaction
 };
 
 #[test]
@@ -34,8 +33,9 @@ fn spl_token() {
         svm.latest_blockhash(),
     ));
     assert!(tx_result.is_ok());
+    let expected_rent = svm.get_sysvar::<Rent>().minimum_balance(spl_token::state::Mint::LEN);
     let balance_after = svm.get_balance(&payer_pk).unwrap();
-    assert!(balance_after < balance_before);
+    assert_eq!(balance_before - balance_after, expected_rent);
 
     let mint_acc = svm.get_account(&mint_kp.pubkey());
     let mint = spl_token::state::Mint::unpack(&mint_acc.unwrap().data).unwrap();

--- a/tests/spl.rs
+++ b/tests/spl.rs
@@ -1,6 +1,7 @@
 use litesvm::LiteSVM;
 use solana_sdk::{
-    program_pack::Pack, rent::Rent, signature::Keypair, signer::Signer, system_instruction, transaction::Transaction
+    program_pack::Pack, rent::Rent, signature::Keypair, signer::Signer, system_instruction,
+    transaction::Transaction,
 };
 
 #[test]
@@ -26,6 +27,7 @@ fn spl_token() {
         spl_token::instruction::initialize_mint2(&spl_token::id(), &mint_pk, &payer_pk, None, 8)
             .unwrap();
     let balance_before = svm.get_balance(&payer_pk).unwrap();
+    let expected_fee = 2 * 5000; // two signers
     let tx_result = svm.send_transaction(Transaction::new_signed_with_payer(
         &[create_acc_ins, init_mint_ins],
         Some(&payer_pk),
@@ -33,9 +35,12 @@ fn spl_token() {
         svm.latest_blockhash(),
     ));
     assert!(tx_result.is_ok());
-    let expected_rent = svm.get_sysvar::<Rent>().minimum_balance(spl_token::state::Mint::LEN);
+    let expected_rent = svm
+        .get_sysvar::<Rent>()
+        .minimum_balance(spl_token::state::Mint::LEN);
     let balance_after = svm.get_balance(&payer_pk).unwrap();
-    assert_eq!(balance_before - balance_after, expected_rent);
+
+    assert_eq!(balance_before - balance_after, expected_rent + expected_fee);
 
     let mint_acc = svm.get_account(&mint_kp.pubkey());
     let mint = spl_token::state::Mint::unpack(&mint_acc.unwrap().data).unwrap();


### PR DESCRIPTION
- Subtracts the base fee from the payer account for both successful and failed transactions. "Failed" transaction here is supposed to mean a transaction that would get included in a block with an error code, as opposed to one that just gets dropped.
- Added some error logs to make it easier to tell where errors occurred. These are noops unless the user activates them with env_logger or whatever
- Changed the transaction history to include failed transactions (sorry for putting this all in one PR)
