### PR TITLE
feat: avoid mut constraint for simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@
 
 ### 🔧 Installation
 
-Solana CLI >= 1.18.8 required.
-
 ```sh
 cargo add --dev litesvm
 ```
@@ -56,3 +54,7 @@ fn system_transfer() {
     assert_eq!(to_account.unwrap().lamports, 64);
 }
 ```
+
+### Development
+
+Solana CLI >= 1.18.8 required.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
 
 ## 🚀 Getting Started
 
-
 ### 🔧 Installation
+
+Solana CLI >= 1.18.8 required.
 
 ```sh
 cargo add --dev litesvm

--- a/bench.sh
+++ b/bench.sh
@@ -1,2 +1,8 @@
 #!/usr/bin/bash
+ROOT=$(git rev-parse --show-toplevel)
+
+cd $ROOT/test_programs
+cargo build-sbf
+
+cd $ROOT
 RUST_LOG= cargo bench --features internal-test


### PR DESCRIPTION
In cases where this is used as an a amnesiac executor, the `self mut` on the tx processing functions unnecessarily prevent parallelisation due to a [single shared line](https://github.com/LiteSVM/litesvm/blob/7973d9bb8bae1082f88d956330bd7188dcd9cff3/src/lib.rs#L695).

This PR splits the necessary code into a read-only branch that gets used by the `simulate` function, and allows the removal of `mut` for self.

It does introduce a bit of duplication between `execute_sanitized_transaction_readonly` and `execute_sanitized_transaction` and the naming might be suboptimal. If you have proposal to make it cleaner on those points lmk.