### PR TITLE
use unwrap in readme example instead of assert!(tx_res.is_ok())

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,10 @@ fn system_transfer() {
         Message::new(&[instruction], Some(&from)),
         svm.latest_blockhash(),
     );
-    let tx_res = svm.send_transaction(tx);
+    let tx_res = svm.send_transaction(tx).unwrap();
 
     let from_account = svm.get_account(&from);
     let to_account = svm.get_account(&to);
-    assert!(tx_res.is_ok());
     assert_eq!(from_account.unwrap().lamports, 4936);
     assert_eq!(to_account.unwrap().lamports, 64);
 }


### PR DESCRIPTION
This way is more convenient because it will show you error information