### PR TITLE
parses inner instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@
 - Implement blockhash and durable nonce checks ([#61](https://github.com/LiteSVM/litesvm/pull/61)).
 - Add `error.rs` and new `LiteSVMError` type ([#62](https://github.com/LiteSVM/litesvm/pull/62)).
 - Add more logging for users to make debugging errors easier ([#62](https://github.com/LiteSVM/litesvm/pull/62)).
+- Add `inner_instructions` to `TransactionMetadata` ([#75](https://github.com/LiteSVM/litesvm/pull/75)).
 
 ### Changed
 
-- Accept both legacy and versioned tx in simulate_transaction ([#58](https://github.com/LiteSVM/litesvm/pull/58)).
+- Accept both legacy and versioned tx in `simulate_transaction` ([#58](https://github.com/LiteSVM/litesvm/pull/58)).
 - Move `InvalidSysvarDataError` to `error.rs` ([#62](https://github.com/LiteSVM/litesvm/pull/62)).
 - Change `set_account` to return `Result<(), LiteSVMError>` ([#62](https://github.com/LiteSVM/litesvm/pull/62)).
 - Replace `&mut self` with `&self` in `simulate_transaction`. ([#64](https://github.com/LiteSVM/litesvm/pull/64)).

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,6 @@
 use solana_sdk::{
     account::AccountSharedData,
+    inner_instruction::InnerInstructionsList,
     pubkey::Pubkey,
     signature::Signature,
     transaction::{Result, TransactionError},
@@ -10,6 +11,7 @@ use solana_sdk::{
 pub struct TransactionMetadata {
     pub signature: Signature,
     pub logs: Vec<String>,
+    pub inner_instructions: InnerInstructionsList,
     pub compute_units_consumed: u64,
     pub return_data: TransactionReturnData,
 }
@@ -27,6 +29,7 @@ pub(crate) struct ExecutionResult {
     pub(crate) tx_result: Result<()>,
     pub(crate) signature: Signature,
     pub(crate) compute_units_consumed: u64,
+    pub(crate) inner_instructions: InnerInstructionsList,
     pub(crate) return_data: TransactionReturnData,
     /// Whether the transaction can be included in a block
     pub(crate) included: bool,
@@ -39,6 +42,7 @@ impl Default for ExecutionResult {
             tx_result: Err(TransactionError::UnsupportedVersion),
             signature: Default::default(),
             compute_units_consumed: Default::default(),
+            inner_instructions: Default::default(),
             return_data: Default::default(),
             included: false,
         }

--- a/src/utils/inner_instructions.rs
+++ b/src/utils/inner_instructions.rs
@@ -1,0 +1,58 @@
+use solana_sdk::{
+    inner_instruction::{InnerInstruction, InnerInstructionsList},
+    instruction::{CompiledInstruction, TRANSACTION_LEVEL_STACK_HEIGHT},
+    transaction_context::TransactionContext,
+};
+
+
+/// Pulled verbatim from `solana-svm` crate, `transaction_processor.rs`
+pub fn inner_instructions_list_from_instruction_trace(
+    transaction_context: &TransactionContext,
+) -> InnerInstructionsList {
+    debug_assert!(transaction_context
+        .get_instruction_context_at_index_in_trace(0)
+        .map(|instruction_context| instruction_context.get_stack_height()
+            == TRANSACTION_LEVEL_STACK_HEIGHT)
+        .unwrap_or(true));
+    let mut outer_instructions = Vec::new();
+    for index_in_trace in 0..transaction_context.get_instruction_trace_length() {
+        if let Ok(instruction_context) =
+            transaction_context.get_instruction_context_at_index_in_trace(index_in_trace)
+        {
+            let stack_height = instruction_context.get_stack_height();
+            if stack_height == TRANSACTION_LEVEL_STACK_HEIGHT {
+                outer_instructions.push(Vec::new());
+            } else if let Some(inner_instructions) = outer_instructions.last_mut() {
+                let stack_height = u8::try_from(stack_height).unwrap_or(u8::MAX);
+                let instruction = CompiledInstruction::new_from_raw_parts(
+                    instruction_context
+                        .get_index_of_program_account_in_transaction(
+                            instruction_context
+                                .get_number_of_program_accounts()
+                                .saturating_sub(1),
+                        )
+                        .unwrap_or_default() as u8,
+                    instruction_context.get_instruction_data().to_vec(),
+                    (0..instruction_context.get_number_of_instruction_accounts())
+                        .map(|instruction_account_index| {
+                            instruction_context
+                                .get_index_of_instruction_account_in_transaction(
+                                    instruction_account_index,
+                                )
+                                .unwrap_or_default() as u8
+                        })
+                        .collect(),
+                );
+                inner_instructions.push(InnerInstruction {
+                    instruction,
+                    stack_height,
+                });
+            } else {
+                debug_assert!(false);
+            }
+        } else {
+            debug_assert!(false);
+        }
+    }
+    outer_instructions
+}

--- a/src/utils/inner_instructions.rs
+++ b/src/utils/inner_instructions.rs
@@ -4,7 +4,6 @@ use solana_sdk::{
     transaction_context::TransactionContext,
 };
 
-
 /// Pulled verbatim from `solana-svm` crate, `transaction_processor.rs`
 pub fn inner_instructions_list_from_instruction_trace(
     transaction_context: &TransactionContext,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@ use solana_sdk::{
 };
 
 pub mod rent;
+pub mod inner_instructions;
 
 /// Create a blockhash from the given bytes
 pub fn create_blockhash(bytes: &[u8]) -> Hash {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,8 +5,8 @@ use solana_sdk::{
     sysvar::{self, instructions::construct_instructions_data},
 };
 
-pub mod rent;
 pub mod inner_instructions;
+pub mod rent;
 
 /// Create a blockhash from the given bytes
 pub fn create_blockhash(bytes: &[u8]) -> Hash {

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -1,0 +1,40 @@
+use litesvm::LiteSVM;
+use solana_address_lookup_table_program::instruction::{create_lookup_table, extend_lookup_table};
+use solana_sdk::{
+    message::Message, pubkey::Pubkey, signature::Keypair, signer::Signer, transaction::Transaction,
+};
+
+#[test]
+fn test_inner_instruction_parsing() {
+    let mut svm = LiteSVM::new();
+    let payer_kp = Keypair::new();
+    let payer_pk = payer_kp.pubkey();
+    svm.airdrop(&payer_pk, 1000000000).unwrap();
+    let blockhash = svm.latest_blockhash();
+    let (lookup_table_ix, lookup_table_address) = create_lookup_table(payer_pk, payer_pk, 0);
+    let extend_ix = extend_lookup_table(
+        lookup_table_address,
+        payer_pk,
+        Some(payer_pk),
+        vec![Pubkey::new_unique()],
+    );
+    let lookup_msg = Message::new(&[lookup_table_ix, extend_ix], Some(&payer_pk));
+    let lookup_tx = Transaction::new(&[&payer_kp], lookup_msg, blockhash);
+    let result = svm.send_transaction(lookup_tx).unwrap();
+    assert_eq!(2, result.inner_instructions.len());
+    assert_eq!(3, result.inner_instructions[0].len());
+    assert_eq!(1, result.inner_instructions[1].len());
+    assert_eq!(2, result.inner_instructions[0][0].stack_height);
+    assert_eq!(
+        2,
+        result.inner_instructions[0][0].instruction.program_id_index,
+    );
+    assert_eq!(
+        vec![0, 1],
+        result.inner_instructions[0][0].instruction.accounts
+    );
+    assert_eq!(
+        vec![2, 0, 0, 0, 128, 138, 19, 0, 0, 0, 0, 0],
+        result.inner_instructions[0][0].instruction.data
+    );
+}


### PR DESCRIPTION
This PR mostly pulls in [this function](https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/svm/src/transaction_processor.rs#L873) from the `solana-svm` crate and includes the list of inner instructions as part of the metadata returned. It's very useful for a variety of use cases, for example in retrieving event data that gets emitted as a no-op CPI.

Edit: fixed lint + added a test