### PR TITLE
adds feature-gated serde traits to TransactionMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `error.rs` and new `LiteSVMError` type ([#62](https://github.com/LiteSVM/litesvm/pull/62)).
 - Add more logging for users to make debugging errors easier ([#62](https://github.com/LiteSVM/litesvm/pull/62)).
 - Add `inner_instructions` to `TransactionMetadata` ([#75](https://github.com/LiteSVM/litesvm/pull/75)).
+- Add feature-flagged `serde` traits to `TransactionMetadata` ([#77](https://github.com/LiteSVM/litesvm/pull/77)).
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ log = "0.4.21"
 solana-vote-program = "~1.18"
 solana-stake-program = "~1.18"
 solana-config-program = "~1.18"
+serde = { version = "1.0.197", optional = true }
 
 [dev-dependencies]
 spl-token = "3.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4.21"
 solana-vote-program = "~1.18"
 solana-stake-program = "~1.18"
 solana-config-program = "~1.18"
-serde = { version = "1.0.197", optional = true }
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 spl-token = "3.5.0"
@@ -34,7 +34,7 @@ criterion = "0.5"
 tokio = "1.35"
 test-log = "0.2.15"
 solana-config-program = "~1.18"
-serde = "1.0.197"
+serde = "1.0"
 
 [features]
 internal-test = []

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,7 +8,9 @@ use solana_sdk::{
 };
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransactionMetadata {
+    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde_with_str"))]
     pub signature: Signature,
     pub logs: Vec<String>,
     pub inner_instructions: InnerInstructionsList,
@@ -17,6 +19,7 @@ pub struct TransactionMetadata {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FailedTransactionMetadata {
     pub err: TransactionError,
     pub meta: TransactionMetadata,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,8 @@ use solana_sdk::{
 
 pub mod inner_instructions;
 pub mod rent;
+#[cfg(feature = "serde")]
+pub mod serde_with_str;
 
 /// Create a blockhash from the given bytes
 pub fn create_blockhash(bytes: &[u8]) -> Hash {

--- a/src/utils/serde_with_str.rs
+++ b/src/utils/serde_with_str.rs
@@ -1,0 +1,24 @@
+use {
+    serde::{de, Deserializer, Serializer},
+    serde::{Deserialize, Serialize},
+    std::str::FromStr,
+};
+
+pub fn serialize<T, S>(t: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: ToString,
+    S: Serializer,
+{
+    t.to_string().serialize(serializer)
+}
+
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: FromStr,
+    D: Deserializer<'de>,
+    <T as FromStr>::Err: std::fmt::Debug,
+{
+    let s: String = String::deserialize(deserializer)?;
+    s.parse()
+        .map_err(|e| de::Error::custom(format!("Parse error: {e:?}")))
+}


### PR DESCRIPTION
Another simple one. Adds feature-flagged `serde` traits on `TransactionMetadata` and `FailedTransactionMetadata`. This will be useful for use cases involving sending the transaction results over the wire. 

The requisite `serde` traits are already added on struct fields coming from `solana-sdk`. (De-)serializing `Signature` to/from string. 

I didn't add `serde` to the default features of the crate, up to you.