### PR TITLE
feat: Add ability to feed in custom feature set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Replace `&mut self` with `&self` in `simulate_transaction`. ([#64](https://github.com/LiteSVM/litesvm/pull/64)).
 - Remove `set_compute_budget` as it duplicates `with_compute_budget`. ([#68](https://github.com/LiteSVM/litesvm/pull/68)).
 - Remove `set_upgrade_authority` and `deploy_upgradeable_program` ([#69](https://github.com/LiteSVM/litesvm/pull/69)).
+- Change `with_builtins` to take a feature_set argument `Option<FeatureSet>` ([#81](https://github.com/LiteSVM/litesvm/pull/81)).
 
 ## [0.1.0] - 2024-04-02
 
@@ -30,4 +31,3 @@
 
 [Unreleased]: https://github.com/LiteSVM/litesvm/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/LiteSVM/litesvm/releases/tag/v0.1.0
-

--- a/svm/src/lib.rs
+++ b/svm/src/lib.rs
@@ -108,7 +108,7 @@ impl Default for LiteSVM {
 impl LiteSVM {
     pub fn new() -> Self {
         LiteSVM::default()
-            .with_builtins()
+            .with_builtins(None)
             .with_lamports(1_000_000u64.wrapping_mul(LAMPORTS_PER_SOL))
             .with_sysvars()
             .with_spl_programs()
@@ -156,8 +156,8 @@ impl LiteSVM {
         self
     }
 
-    pub fn with_builtins(mut self) -> Self {
-        let mut feature_set = FeatureSet::all_enabled();
+    pub fn with_builtins(mut self, feature_set: Option<FeatureSet>) -> Self {
+        let mut feature_set = feature_set.unwrap_or(FeatureSet::all_enabled());
 
         BUILTINS.iter().for_each(|builtint| {
             let loaded_program =


### PR DESCRIPTION
Problem:

If one wants to test with only activated features on mainnet or some peculiar cocktail, the entire `with_builtins` logic needs to be copied out.

Instead allow with_builtins to take `feature_set: Option<FeatureSet>` to let people toggle what they want.

This breaks the public interface