### PR TITLE
fix: fixed sigverify in node-litesvm

### DIFF
--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -1225,6 +1225,10 @@ impl LiteSVM {
         self.compute_budget
     }
 
+    pub fn get_sigverify(&self) -> bool {
+        self.sigverify
+    }
+
     #[cfg(feature = "internal-test")]
     pub fn get_feature_set(&self) -> Arc<FeatureSet> {
         self.feature_set.clone()

--- a/crates/node-litesvm/litesvm/index.ts
+++ b/crates/node-litesvm/litesvm/index.ts
@@ -330,8 +330,11 @@ export class LiteSVM {
 	simulateTransaction(
 		tx: Transaction | VersionedTransaction,
 	): FailedTransactionMetadata | SimulatedTransactionInfo {
-		const serialized = tx.serialize();
 		const internal = this.inner;
+		const serialized = tx.serialize({
+			requireAllSignatures: true,
+			verifySignatures: internal.getSigverify(),
+		});
 		const inner =
 			tx instanceof Transaction
 				? internal.simulateLegacyTransaction(serialized)

--- a/crates/node-litesvm/litesvm/index.ts
+++ b/crates/node-litesvm/litesvm/index.ts
@@ -309,8 +309,12 @@ export class LiteSVM {
 	sendTransaction(
 		tx: Transaction | VersionedTransaction,
 	): TransactionMetadata | FailedTransactionMetadata {
-		const serialized = tx.serialize();
 		const internal = this.inner;
+		const serialized = tx.serialize({
+			requireAllSignatures: true,
+			verifySignatures: internal.getSigverify(),
+		});
+
 		if (tx instanceof Transaction) {
 			return internal.sendLegacyTransaction(serialized);
 		} else {

--- a/crates/node-litesvm/litesvm/internal.d.ts
+++ b/crates/node-litesvm/litesvm/internal.d.ts
@@ -563,6 +563,7 @@ export declare class LiteSvm {
   /** Warps the clock to the specified slot */
   warpToSlot(slot: bigint): void
   getComputeBudget(): ComputeBudget | null
+  getSigverify(): boolean
   getClock(): Clock
   setClock(clock: Clock): void
   getRent(): Rent

--- a/crates/node-litesvm/src/lib.rs
+++ b/crates/node-litesvm/src/lib.rs
@@ -283,7 +283,7 @@ impl LiteSvm {
     }
 
     #[napi]
-    pub fn get_sigverify(&mut self) -> bool {
+    pub fn get_sigverify(&self) -> bool {
         self.0.get_sigverify()
     }
 

--- a/crates/node-litesvm/src/lib.rs
+++ b/crates/node-litesvm/src/lib.rs
@@ -281,6 +281,11 @@ impl LiteSvm {
     pub fn get_compute_budget(&self) -> Option<ComputeBudget> {
         self.0.get_compute_budget().map(ComputeBudget)
     }
+    
+    #[napi]
+    pub fn get_sigverify(&mut self) -> bool {
+        self.0.get_sigverify()
+    }
 
     #[napi]
     pub fn get_clock(&self) -> Clock {

--- a/crates/node-litesvm/src/lib.rs
+++ b/crates/node-litesvm/src/lib.rs
@@ -281,7 +281,7 @@ impl LiteSvm {
     pub fn get_compute_budget(&self) -> Option<ComputeBudget> {
         self.0.get_compute_budget().map(ComputeBudget)
     }
-    
+
     #[napi]
     pub fn get_sigverify(&mut self) -> bool {
         self.0.get_sigverify()

--- a/crates/node-litesvm/tests/getTransaction.test.ts
+++ b/crates/node-litesvm/tests/getTransaction.test.ts
@@ -30,6 +30,6 @@ test("hello world", () => {
 	const greetedAccountAfter = svm.getAccount(greetedPubkey);
 	expect(greetedAccountAfter).not.toBeNull();
 	expect(greetedAccountAfter?.data).toEqual(new Uint8Array([1, 0, 0, 0]));
-    const fetched = svm.getTransaction(tx.signature);
-    expect(fetched).toBeInstanceOf(TransactionMetadata);
+	const fetched = svm.getTransaction(tx.signature);
+	expect(fetched).toBeInstanceOf(TransactionMetadata);
 });

--- a/crates/node-litesvm/tests/sigVerify.test.ts
+++ b/crates/node-litesvm/tests/sigVerify.test.ts
@@ -1,35 +1,35 @@
 import {
-    LAMPORTS_PER_SOL,
-    Transaction,
-    TransactionInstruction,
-    PublicKey,
+	LAMPORTS_PER_SOL,
+	Transaction,
+	TransactionInstruction,
+	PublicKey,
 } from "@solana/web3.js";
 import { helloworldProgram } from "./util";
 
 test("test sigverify", () => {
-    let [svm, programId, greetedPubkey] = helloworldProgram();
-    svm = svm.withSigverify(false);
-    const payerPubkey = new PublicKey(12345);
-    const fakeSigner = {
-        publicKey: payerPubkey,
-        secretKey: new Uint8Array(32),
-    } // note that the secretKey & publicKey do not match
-    svm.airdrop(payerPubkey, BigInt(LAMPORTS_PER_SOL));
-    const blockhash = svm.latestBlockhash();
-    const greetedAccountBefore = svm.getAccount(greetedPubkey);
-    expect(greetedAccountBefore).not.toBeNull();
-    expect(greetedAccountBefore?.data).toEqual(new Uint8Array([0, 0, 0, 0]));
-    const ix = new TransactionInstruction({
-        keys: [{ pubkey: greetedPubkey, isSigner: false, isWritable: true }],
-        programId,
-        data: Buffer.from([0]),
-    });
-    const tx = new Transaction();
-    tx.recentBlockhash = blockhash;
-    tx.add(ix);
-    tx.sign(fakeSigner);
-    svm.sendTransaction(tx);
-    const greetedAccountAfter = svm.getAccount(greetedPubkey);
-    expect(greetedAccountAfter).not.toBeNull();
-    expect(greetedAccountAfter?.data).toEqual(new Uint8Array([1, 0, 0, 0]));
+	let [svm, programId, greetedPubkey] = helloworldProgram();
+	svm = svm.withSigverify(false);
+	const payerPubkey = new PublicKey(12345);
+	const fakeSigner = {
+		publicKey: payerPubkey,
+		secretKey: new Uint8Array(32),
+	}; // note that the secretKey & publicKey do not match
+	svm.airdrop(payerPubkey, BigInt(LAMPORTS_PER_SOL));
+	const blockhash = svm.latestBlockhash();
+	const greetedAccountBefore = svm.getAccount(greetedPubkey);
+	expect(greetedAccountBefore).not.toBeNull();
+	expect(greetedAccountBefore?.data).toEqual(new Uint8Array([0, 0, 0, 0]));
+	const ix = new TransactionInstruction({
+		keys: [{ pubkey: greetedPubkey, isSigner: false, isWritable: true }],
+		programId,
+		data: Buffer.from([0]),
+	});
+	const tx = new Transaction();
+	tx.recentBlockhash = blockhash;
+	tx.add(ix);
+	tx.sign(fakeSigner);
+	svm.sendTransaction(tx);
+	const greetedAccountAfter = svm.getAccount(greetedPubkey);
+	expect(greetedAccountAfter).not.toBeNull();
+	expect(greetedAccountAfter?.data).toEqual(new Uint8Array([1, 0, 0, 0]));
 });

--- a/crates/node-litesvm/tests/sigVerify.test.ts
+++ b/crates/node-litesvm/tests/sigVerify.test.ts
@@ -1,0 +1,35 @@
+import {
+	LAMPORTS_PER_SOL,
+	Transaction,
+	TransactionInstruction,
+	PublicKey,
+} from "@solana/web3.js";
+import { helloworldProgram } from "./util";
+
+test("test sigverify", () => {
+	let [svm, programId, greetedPubkey] = helloworldProgram();
+    svm = svm.withSigverify(false);
+    const payerPubkey = new PublicKey(12345);
+    const fakeSigner = {
+        publicKey: payerPubkey,
+        secretKey: new Uint8Array(32),
+    } // note that the secretKey & publicKey do not match
+	svm.airdrop(payerPubkey, BigInt(LAMPORTS_PER_SOL));
+	const blockhash = svm.latestBlockhash();
+	const greetedAccountBefore = svm.getAccount(greetedPubkey);
+	expect(greetedAccountBefore).not.toBeNull();
+	expect(greetedAccountBefore?.data).toEqual(new Uint8Array([0, 0, 0, 0]));
+	const ix = new TransactionInstruction({
+		keys: [{ pubkey: greetedPubkey, isSigner: false, isWritable: true }],
+		programId,
+		data: Buffer.from([0]),
+	});
+	const tx = new Transaction();
+	tx.recentBlockhash = blockhash;
+	tx.add(ix);
+	tx.sign(fakeSigner);
+	svm.sendTransaction(tx);
+	const greetedAccountAfter = svm.getAccount(greetedPubkey);
+	expect(greetedAccountAfter).not.toBeNull();
+	expect(greetedAccountAfter?.data).toEqual(new Uint8Array([1, 0, 0, 0]));
+});

--- a/crates/node-litesvm/tests/sigVerify.test.ts
+++ b/crates/node-litesvm/tests/sigVerify.test.ts
@@ -1,35 +1,35 @@
 import {
-	LAMPORTS_PER_SOL,
-	Transaction,
-	TransactionInstruction,
-	PublicKey,
+    LAMPORTS_PER_SOL,
+    Transaction,
+    TransactionInstruction,
+    PublicKey,
 } from "@solana/web3.js";
 import { helloworldProgram } from "./util";
 
 test("test sigverify", () => {
-	let [svm, programId, greetedPubkey] = helloworldProgram();
+    let [svm, programId, greetedPubkey] = helloworldProgram();
     svm = svm.withSigverify(false);
     const payerPubkey = new PublicKey(12345);
     const fakeSigner = {
         publicKey: payerPubkey,
         secretKey: new Uint8Array(32),
     } // note that the secretKey & publicKey do not match
-	svm.airdrop(payerPubkey, BigInt(LAMPORTS_PER_SOL));
-	const blockhash = svm.latestBlockhash();
-	const greetedAccountBefore = svm.getAccount(greetedPubkey);
-	expect(greetedAccountBefore).not.toBeNull();
-	expect(greetedAccountBefore?.data).toEqual(new Uint8Array([0, 0, 0, 0]));
-	const ix = new TransactionInstruction({
-		keys: [{ pubkey: greetedPubkey, isSigner: false, isWritable: true }],
-		programId,
-		data: Buffer.from([0]),
-	});
-	const tx = new Transaction();
-	tx.recentBlockhash = blockhash;
-	tx.add(ix);
-	tx.sign(fakeSigner);
-	svm.sendTransaction(tx);
-	const greetedAccountAfter = svm.getAccount(greetedPubkey);
-	expect(greetedAccountAfter).not.toBeNull();
-	expect(greetedAccountAfter?.data).toEqual(new Uint8Array([1, 0, 0, 0]));
+    svm.airdrop(payerPubkey, BigInt(LAMPORTS_PER_SOL));
+    const blockhash = svm.latestBlockhash();
+    const greetedAccountBefore = svm.getAccount(greetedPubkey);
+    expect(greetedAccountBefore).not.toBeNull();
+    expect(greetedAccountBefore?.data).toEqual(new Uint8Array([0, 0, 0, 0]));
+    const ix = new TransactionInstruction({
+        keys: [{ pubkey: greetedPubkey, isSigner: false, isWritable: true }],
+        programId,
+        data: Buffer.from([0]),
+    });
+    const tx = new Transaction();
+    tx.recentBlockhash = blockhash;
+    tx.add(ix);
+    tx.sign(fakeSigner);
+    svm.sendTransaction(tx);
+    const greetedAccountAfter = svm.getAccount(greetedPubkey);
+    expect(greetedAccountAfter).not.toBeNull();
+    expect(greetedAccountAfter?.data).toEqual(new Uint8Array([1, 0, 0, 0]));
 });


### PR DESCRIPTION
## Context
When sending transactions through [`sendTransaction`](https://github.com/LiteSVM/litesvm/blob/master/crates/node-litesvm/litesvm/index.ts#L309), there are two places in which signature verification is checked:
- [Solana Web 3 JS](https://github.com/solana-labs/solana-web3.js/blob/4e9988cfc561f3ed11f4c5016a29090a61d129a8/src/transaction/legacy.ts#L804)
- [LiteSVM](https://github.com/LiteSVM/litesvm/blob/696b6c8dc2c92dfc7e4adf9b9e026103cc90bacd/crates/litesvm/src/lib.rs#L1129)

Calling [`withSigVerify`](https://github.com/LiteSVM/litesvm/blob/master/crates/node-litesvm/litesvm/index.ts#L123) allows us to bypass the second LiteSVM verification, but the first Web 3 JS verification gets caught and throws an error

## Changes
- Adding a getter function `get_sigverify` to get the value from the rust litesvm node
- Checking the value of `sigverify` and passing it through to the Web 3 JS serialize function

## Testing
A testcase was written for this, showing that the transaction goes through and has the correct outcome with an invalid keypair