### PR TITLE
add log for transaction sanitization failure

### DIFF
--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -703,7 +703,7 @@ impl LiteSVM {
             &ReservedAccountKeys::empty_key_set(),
         );
         res.map_err(|e| {
-            log::error!("Transaction sanitization failed: {:?}", e);
+            log::error!("Transaction sanitization failed");
             e
         })
     }

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -695,13 +695,17 @@ impl LiteSVM {
         &self,
         tx: VersionedTransaction,
     ) -> Result<SanitizedTransaction, TransactionError> {
-        SanitizedTransaction::try_create(
+        let res = SanitizedTransaction::try_create(
             tx,
             MessageHash::Compute,
             Some(false),
             &self.accounts,
             &ReservedAccountKeys::empty_key_set(),
-        )
+        );
+        res.map_err(|e| {
+            log::error!("Transaction sanitization failed: {:?}", e);
+            e
+        })
     }
 
     fn sanitize_transaction_no_verify(


### PR DESCRIPTION
I ran into this error with a malformed transaction. This log makes it a little faster to figure out