### PR TITLE
Fix/disable transaction history

### DIFF
--- a/crates/litesvm/src/history.rs
+++ b/crates/litesvm/src/history.rs
@@ -11,8 +11,9 @@ impl TransactionHistory {
     pub fn set_capacity(&mut self, new_cap: usize) {
         if new_cap == 0 {
             self.0.clear();
-            self.0.shrink_to(0);
-        } else if new_cap <= self.0.capacity() {
+        }
+
+        if new_cap <= self.0.capacity() {
             self.0.shrink_to(new_cap)
         } else {
             self.0.reserve(new_cap - self.0.capacity())
@@ -34,7 +35,6 @@ impl TransactionHistory {
     }
 
     pub fn check_transaction(&self, signature: &Signature) -> bool {
-        println!("capacity: {}", self.0.capacity());
         self.0.capacity() != 0 && self.0.contains_key(signature)
     }
 }

--- a/crates/litesvm/src/history.rs
+++ b/crates/litesvm/src/history.rs
@@ -35,6 +35,6 @@ impl TransactionHistory {
     }
 
     pub fn check_transaction(&self, signature: &Signature) -> bool {
-        self.0.capacity() != 0 && self.0.contains_key(signature)
+        self.0.contains_key(signature)
     }
 }

--- a/crates/litesvm/src/history.rs
+++ b/crates/litesvm/src/history.rs
@@ -9,7 +9,10 @@ impl TransactionHistory {
     }
 
     pub fn set_capacity(&mut self, new_cap: usize) {
-        if new_cap <= self.0.capacity() {
+        if new_cap == 0 {
+            self.0.clear();
+            self.0.shrink_to(0);
+        } else if new_cap <= self.0.capacity() {
             self.0.shrink_to(new_cap)
         } else {
             self.0.reserve(new_cap - self.0.capacity())
@@ -31,6 +34,7 @@ impl TransactionHistory {
     }
 
     pub fn check_transaction(&self, signature: &Signature) -> bool {
-        self.0.contains_key(signature)
+        println!("capacity: {}", self.0.capacity());
+        self.0.capacity() != 0 && self.0.contains_key(signature)
     }
 }

--- a/crates/litesvm/tests/tx_history.rs
+++ b/crates/litesvm/tests/tx_history.rs
@@ -1,0 +1,72 @@
+use litesvm::LiteSVM;
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_system_interface::instruction::transfer;
+use solana_transaction::Transaction;
+
+#[test]
+fn test_tx_history_base_case() {
+    // Create a key for our test transactions
+    let from_keypair = Keypair::new();
+    let from = from_keypair.pubkey();
+    let to = Pubkey::new_unique();
+
+    // Create the VM and airdrop funds
+    let mut svm = LiteSVM::new()
+        .with_sigverify(false)
+        .with_blockhash_check(false)
+        .with_transaction_history(0);
+    svm.airdrop(&from, 10_000_000).unwrap();
+
+    // Try to create and send two identical transactions
+    let instruction = transfer(&from, &to, 100);
+
+    // First transaction - should succeed
+    // Note: unsigned transactions use default (the same) signatures
+    let tx1 = Transaction::new_with_payer(&[instruction.clone()], Some(&from));
+    let result1 = svm.send_transaction(tx1);
+    assert!(result1.is_ok(), "First transaction should succeed");
+
+    // Second duplicate transaction - should succeed
+    let tx2 = Transaction::new_with_payer(&[instruction], Some(&from));
+    let result2 = svm.send_transaction(tx2);
+
+    assert!(!result2.is_err(), "Second transaction should succeed");
+}
+
+/// Setting the transaction history to 0 at any time should disable transaction history
+#[test]
+fn test_tx_history_disable_later() {
+    // Create a key for our test transactions
+    let from_keypair = Keypair::new();
+    let from = from_keypair.pubkey();
+    let to = Pubkey::new_unique();
+
+    // Create the VM and airdrop funds
+    let mut svm = LiteSVM::new()
+        .with_sigverify(false)
+        .with_blockhash_check(false);
+    svm.airdrop(&from, 10_000_000).unwrap();
+
+    // Try to create and send two identical transactions
+    let instruction = transfer(&from, &to, 100);
+
+    // Note: unsigned transactions use default (the same) signatures as the airdrop
+    let tx1 = Transaction::new_with_payer(&[instruction.clone()], Some(&from));
+    let result1 = svm.send_transaction(tx1);
+    assert!(result1.is_ok(), "First transaction should succeed");
+
+    let mut svm = svm.with_transaction_history(0);
+
+    // Second duplicate transaction - should succeed
+    let tx2 = Transaction::new_with_payer(&[instruction], Some(&from));
+    let result2 = svm.send_transaction(tx2.clone());
+
+    println!("result2: {:?}", result2);
+    assert!(!result2.is_err(), "Second transaction should succeed");
+
+    // Get should not panic
+    let result = svm.get_transaction(&tx2.signatures[0]);
+    assert!(result.is_none(), "Transaction should not be in history");
+}

--- a/crates/litesvm/tests/tx_history.rs
+++ b/crates/litesvm/tests/tx_history.rs
@@ -1,9 +1,7 @@
-use litesvm::LiteSVM;
-use solana_keypair::Keypair;
-use solana_pubkey::Pubkey;
-use solana_signer::Signer;
-use solana_system_interface::instruction::transfer;
-use solana_transaction::Transaction;
+use {
+    litesvm::LiteSVM, solana_keypair::Keypair, solana_pubkey::Pubkey, solana_signer::Signer,
+    solana_system_interface::instruction::transfer, solana_transaction::Transaction,
+};
 
 #[test]
 fn test_tx_history_base_case() {
@@ -63,7 +61,6 @@ fn test_tx_history_disable_later() {
     let tx2 = Transaction::new_with_payer(&[instruction], Some(&from));
     let result2 = svm.send_transaction(tx2.clone());
 
-    println!("result2: {:?}", result2);
     assert!(!result2.is_err(), "Second transaction should succeed");
 
     // Get should not panic


### PR DESCRIPTION
This crate is awesome, kudos to you guys. Makes working with the Solana VM so much more pleasant and straightforward.

I did notice a small bug while I was working with LiteSVM, in the `TransactionHistory` object. The intention of existing code is that calling `with_transaction_history(0)` will disable duplicate transaction checking, such as for unsigned txs with default signatures. But the problem is that `TransactionHistory::set_capacity` does not drop elements already in the history. Specifically, `TransactionHistory` uses an `IndexMap` on which it calls `shrink_to`

```
if new_cap <= self.0.capacity() {
  self.0.shrink_to(new_cap)
}
```

but IndexMap uses a HashTable underneath which only shrinks to the max of the number of existing elements and the input value ([ref1](https://rust-lang.github.io/hashbrown/hashbrown/raw/struct.RawTable.html#method.shrink_to), [ref2](https://docs.rs/indexmap/latest/src/indexmap/map/core.rs.html#301), [ref3](https://docs.rs/indexmap/latest/src/indexmap/map/core.rs.html#303))

So the capacity is not actually set to 0 and any transactions in the history prior to calling `with_transaction_history(0)` still persists (and fails subsequent transactions).

One simple fix, in this PR, is to clear the contents of the IndexMap before shrinking. Also added some quick tests to confirm this. Another way to do this would be to separate the notion of "disabling / clearing" from "setting capacity", which feels cleaner but requires a bigger change and is probably overkill for now.