### PR TITLE
Fix transaction history truncation

### DIFF
--- a/crates/litesvm/src/history.rs
+++ b/crates/litesvm/src/history.rs
@@ -11,8 +11,9 @@ impl TransactionHistory {
     pub fn set_capacity(&mut self, new_cap: usize) {
         if new_cap == 0 {
             self.0.clear();
-            self.0.shrink_to(0);
-        } else if new_cap <= self.0.capacity() {
+        }
+
+        if new_cap <= self.0.capacity() {
             self.0.shrink_to(new_cap)
         } else {
             self.0.reserve(new_cap - self.0.capacity())
@@ -34,7 +35,6 @@ impl TransactionHistory {
     }
 
     pub fn check_transaction(&self, signature: &Signature) -> bool {
-        println!("capacity: {}", self.0.capacity());
         self.0.capacity() != 0 && self.0.contains_key(signature)
     }
 }

--- a/crates/litesvm/src/history.rs
+++ b/crates/litesvm/src/history.rs
@@ -35,6 +35,6 @@ impl TransactionHistory {
     }
 
     pub fn check_transaction(&self, signature: &Signature) -> bool {
-        self.0.capacity() != 0 && self.0.contains_key(signature)
+        self.0.contains_key(signature)
     }
 }

--- a/crates/litesvm/src/history.rs
+++ b/crates/litesvm/src/history.rs
@@ -9,12 +9,9 @@ impl TransactionHistory {
     }
 
     pub fn set_capacity(&mut self, new_cap: usize) {
-        if new_cap == 0 {
-            self.0.clear();
-        }
-
         if new_cap <= self.0.capacity() {
-            self.0.shrink_to(new_cap)
+            self.0.truncate(new_cap);
+            self.0.shrink_to_fit();
         } else {
             self.0.reserve(new_cap - self.0.capacity())
         }

--- a/crates/litesvm/src/history.rs
+++ b/crates/litesvm/src/history.rs
@@ -9,7 +9,10 @@ impl TransactionHistory {
     }
 
     pub fn set_capacity(&mut self, new_cap: usize) {
-        if new_cap <= self.0.capacity() {
+        if new_cap == 0 {
+            self.0.clear();
+            self.0.shrink_to(0);
+        } else if new_cap <= self.0.capacity() {
             self.0.shrink_to(new_cap)
         } else {
             self.0.reserve(new_cap - self.0.capacity())
@@ -31,6 +34,7 @@ impl TransactionHistory {
     }
 
     pub fn check_transaction(&self, signature: &Signature) -> bool {
-        self.0.contains_key(signature)
+        println!("capacity: {}", self.0.capacity());
+        self.0.capacity() != 0 && self.0.contains_key(signature)
     }
 }

--- a/crates/litesvm/tests/tx_history.rs
+++ b/crates/litesvm/tests/tx_history.rs
@@ -1,0 +1,72 @@
+use litesvm::LiteSVM;
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_system_interface::instruction::transfer;
+use solana_transaction::Transaction;
+
+#[test]
+fn test_tx_history_base_case() {
+    // Create a key for our test transactions
+    let from_keypair = Keypair::new();
+    let from = from_keypair.pubkey();
+    let to = Pubkey::new_unique();
+
+    // Create the VM and airdrop funds
+    let mut svm = LiteSVM::new()
+        .with_sigverify(false)
+        .with_blockhash_check(false)
+        .with_transaction_history(0);
+    svm.airdrop(&from, 10_000_000).unwrap();
+
+    // Try to create and send two identical transactions
+    let instruction = transfer(&from, &to, 100);
+
+    // First transaction - should succeed
+    // Note: unsigned transactions use default (the same) signatures
+    let tx1 = Transaction::new_with_payer(&[instruction.clone()], Some(&from));
+    let result1 = svm.send_transaction(tx1);
+    assert!(result1.is_ok(), "First transaction should succeed");
+
+    // Second duplicate transaction - should succeed
+    let tx2 = Transaction::new_with_payer(&[instruction], Some(&from));
+    let result2 = svm.send_transaction(tx2);
+
+    assert!(!result2.is_err(), "Second transaction should succeed");
+}
+
+/// Setting the transaction history to 0 at any time should disable transaction history
+#[test]
+fn test_tx_history_disable_later() {
+    // Create a key for our test transactions
+    let from_keypair = Keypair::new();
+    let from = from_keypair.pubkey();
+    let to = Pubkey::new_unique();
+
+    // Create the VM and airdrop funds
+    let mut svm = LiteSVM::new()
+        .with_sigverify(false)
+        .with_blockhash_check(false);
+    svm.airdrop(&from, 10_000_000).unwrap();
+
+    // Try to create and send two identical transactions
+    let instruction = transfer(&from, &to, 100);
+
+    // Note: unsigned transactions use default (the same) signatures as the airdrop
+    let tx1 = Transaction::new_with_payer(&[instruction.clone()], Some(&from));
+    let result1 = svm.send_transaction(tx1);
+    assert!(result1.is_ok(), "First transaction should succeed");
+
+    let mut svm = svm.with_transaction_history(0);
+
+    // Second duplicate transaction - should succeed
+    let tx2 = Transaction::new_with_payer(&[instruction], Some(&from));
+    let result2 = svm.send_transaction(tx2.clone());
+
+    println!("result2: {:?}", result2);
+    assert!(!result2.is_err(), "Second transaction should succeed");
+
+    // Get should not panic
+    let result = svm.get_transaction(&tx2.signatures[0]);
+    assert!(result.is_none(), "Transaction should not be in history");
+}

--- a/crates/litesvm/tests/tx_history.rs
+++ b/crates/litesvm/tests/tx_history.rs
@@ -1,9 +1,7 @@
-use litesvm::LiteSVM;
-use solana_keypair::Keypair;
-use solana_pubkey::Pubkey;
-use solana_signer::Signer;
-use solana_system_interface::instruction::transfer;
-use solana_transaction::Transaction;
+use {
+    litesvm::LiteSVM, solana_keypair::Keypair, solana_pubkey::Pubkey, solana_signer::Signer,
+    solana_system_interface::instruction::transfer, solana_transaction::Transaction,
+};
 
 #[test]
 fn test_tx_history_base_case() {
@@ -63,7 +61,6 @@ fn test_tx_history_disable_later() {
     let tx2 = Transaction::new_with_payer(&[instruction], Some(&from));
     let result2 = svm.send_transaction(tx2.clone());
 
-    println!("result2: {:?}", result2);
     assert!(!result2.is_err(), "Second transaction should succeed");
 
     // Get should not panic

--- a/crates/litesvm/tests/tx_history.rs
+++ b/crates/litesvm/tests/tx_history.rs
@@ -30,7 +30,7 @@ fn test_tx_history_base_case() {
     let tx2 = Transaction::new_with_payer(&[instruction], Some(&from));
     let result2 = svm.send_transaction(tx2);
 
-    assert!(!result2.is_err(), "Second transaction should succeed");
+    assert!(result2.is_ok(), "Second transaction should succeed");
 }
 
 /// Setting the transaction history to 0 at any time should disable transaction history
@@ -61,7 +61,7 @@ fn test_tx_history_disable_later() {
     let tx2 = Transaction::new_with_payer(&[instruction], Some(&from));
     let result2 = svm.send_transaction(tx2.clone());
 
-    assert!(!result2.is_err(), "Second transaction should succeed");
+    assert!(result2.is_ok(), "Second transaction should succeed");
 
     // Get should not panic
     let result = svm.get_transaction(&tx2.signatures[0]);


### PR DESCRIPTION
Adding `.truncate` and `.shrink_to_fit` to #160 

Closes #160 