### PR TITLE
Make 'add_program' return a error if the program is invalid

### DIFF
--- a/crates/litesvm/src/error.rs
+++ b/crates/litesvm/src/error.rs
@@ -28,4 +28,6 @@ pub enum LiteSVMError {
     InvalidSysvarData(#[from] InvalidSysvarDataError),
     #[error("{0}")]
     Instruction(#[from] InstructionError),
+    #[error("{0}")]
+    InvalidPath(#[from] std::io::Error),
 }

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -662,14 +662,18 @@ impl LiteSVM {
         &mut self,
         program_id: impl Into<Pubkey>,
         path: impl AsRef<Path>,
-    ) -> Result<(), std::io::Error> {
+    ) -> Result<(), LiteSVMError> {
         let bytes = std::fs::read(path)?;
-        self.add_program(program_id, &bytes);
+        self.add_program(program_id, &bytes)?;
         Ok(())
     }
 
     /// Adds am SBF program to the test environment.
-    pub fn add_program(&mut self, program_id: impl Into<Pubkey>, program_bytes: &[u8]) {
+    pub fn add_program(
+        &mut self,
+        program_id: impl Into<Pubkey>,
+        program_bytes: &[u8],
+    ) -> Result<(), LiteSVMError> {
         let program_id = program_id.into();
         let program_len = program_bytes.len();
         let lamports = self.minimum_balance_for_rent_exemption(program_len);
@@ -698,10 +702,11 @@ impl LiteSVM {
         )
         .unwrap_or_default();
         loaded_program.effective_slot = current_slot;
-        self.accounts.add_account(program_id, account).unwrap();
+        self.accounts.add_account(program_id, account)?;
         self.accounts
             .programs_cache
             .replenish(program_id, Arc::new(loaded_program));
+        Ok(())
     }
 
     fn create_transaction_context(

--- a/crates/litesvm/src/spl/mod.rs
+++ b/crates/litesvm/src/spl/mod.rs
@@ -4,21 +4,26 @@ pub fn load_spl_programs(svm: &mut LiteSVM) {
     svm.add_program(
         pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
         include_bytes!("programs/spl_token-3.5.0.so"),
-    );
+    )
+    .unwrap();
     svm.add_program(
         pubkey!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"),
         include_bytes!("programs/spl_token_2022-5.0.2.so"),
-    );
+    )
+    .unwrap();
     svm.add_program(
         pubkey!("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo"),
         include_bytes!("programs/spl_memo-1.0.0.so"),
-    );
+    )
+    .unwrap();
     svm.add_program(
         pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
         include_bytes!("programs/spl_memo-3.0.0.so"),
-    );
+    )
+    .unwrap();
     svm.add_program(
         pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"),
         include_bytes!("programs/spl_associated_token_account-1.1.1.so"),
-    );
+    )
+    .unwrap();
 }

--- a/crates/litesvm/tests/counter_test.rs
+++ b/crates/litesvm/tests/counter_test.rs
@@ -32,7 +32,7 @@ pub fn integration_test() {
     let payer_kp = Keypair::new();
     let payer_pk = payer_kp.pubkey();
     let program_id = pubkey!("GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2");
-    svm.add_program(program_id, &read_counter_program());
+    svm.add_program(program_id, &read_counter_program()).unwrap();
     svm.airdrop(&payer_pk, 1000000000).unwrap();
     let blockhash = svm.latest_blockhash();
     let counter_address = pubkey!("J39wvrFY2AkoAUCke5347RMNk3ditxZfVidoZ7U6Fguf");
@@ -247,7 +247,7 @@ fn test_address_lookup_table() {
     let payer_kp = Keypair::new();
     let payer_pk = payer_kp.pubkey();
     let program_id = pubkey!("GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2");
-    svm.add_program(program_id, &read_counter_program());
+    svm.add_program(program_id, &read_counter_program()).unwrap();
     svm.airdrop(&payer_pk, 1000000000).unwrap();
     let blockhash = svm.latest_blockhash();
     let counter_address = pubkey!("J39wvrFY2AkoAUCke5347RMNk3ditxZfVidoZ7U6Fguf");

--- a/crates/litesvm/tests/test_dflow_load.rs
+++ b/crates/litesvm/tests/test_dflow_load.rs
@@ -9,5 +9,6 @@ fn test_dflow_load() {
     svm.add_program(
         pubkey!("DF1ow3DqMj3HvTj8i8J9yM2hE9hCrLLXpdbaKZu4ZPnz"),
         program_bytes,
-    );
+    )
+    .unwrap();
 }

--- a/crates/loader/tests/loader.rs
+++ b/crates/loader/tests/loader.rs
@@ -23,7 +23,7 @@ fn hello_world_with_store() {
 
     let program_kp = Keypair::new();
     let program_id = program_kp.pubkey();
-    svm.add_program(program_id, program_bytes);
+    svm.add_program(program_id, program_bytes).unwrap();
 
     let instruction = Instruction::new_with_bytes(
         program_id,

--- a/crates/node-litesvm/src/lib.rs
+++ b/crates/node-litesvm/src/lib.rs
@@ -236,9 +236,15 @@ impl LiteSvm {
 
     #[napi]
     /// Adds am SBF program to the test environment.
-    pub fn add_program(&mut self, program_id: Uint8Array, program_bytes: &[u8]) {
+    pub fn add_program(&mut self, program_id: Uint8Array, program_bytes: &[u8]) -> Result<()> {
         self.0
             .add_program(convert_pubkey(program_id), program_bytes)
+            .map_err(|e| {
+                Error::new(
+                    Status::GenericFailure,
+                    format!("Failed to add program: {e}"),
+                )
+            })
     }
 
     #[napi(ts_return_type = "TransactionMetadata | FailedTransactionMetadata")]


### PR DESCRIPTION
Just changed the `add_program` and `add_program_from_file` return a error if the program is invalid, instead of just panicking