### PR TITLE
Add has_account()

### DIFF
--- a/crates/litesvm/src/accounts_db.rs
+++ b/crates/litesvm/src/accounts_db.rs
@@ -65,6 +65,10 @@ pub(crate) struct AccountsDb {
 }
 
 impl AccountsDb {
+    pub(crate) fn has_account(&self, pubkey: &Pubkey) -> bool {
+        self.inner.contains_key(pubkey)
+    }
+
     pub(crate) fn get_account(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         self.inner.get(pubkey).map(|acc| acc.to_owned())
     }

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -587,6 +587,11 @@ impl LiteSVM {
         self.accounts.get_account(pubkey).map(Into::into)
     }
 
+    /// Returns true if the account exists in the AccountsDb.
+    pub fn has_account(&self, pubkey: &Pubkey) -> bool {
+        self.accounts.has_account(pubkey)
+    }
+
     /// Sets all information associated with the account of the provided pubkey.
     pub fn set_account(&mut self, pubkey: Pubkey, data: Account) -> Result<(), LiteSVMError> {
         self.accounts.add_account(pubkey, data.into())


### PR DESCRIPTION
In our use case, we want to loop a large array of accounts to add to the LiteSVM instance.  We don't want to overwrite any accounts that have already been set earlier on.  To filter the list of accounts we were using `svm.get_account(pubkey).is_some()`, however, this is very slow, as if the account exists it will return a copy of the account (+data), when all we need is to know if it exists.

The added function is just a wrapper around the underlying HashMap's `contains_key`, and in our case provides a large amount of speedup when adding accounts.