### PR TITLE
Invocation inspect callback feature

### DIFF
--- a/crates/litesvm/Cargo.toml
+++ b/crates/litesvm/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../../README.md"
 
 [features]
 internal-test = []
+invocation-inspect-callback = []
 nodejs-internal = ["dep:qualifier_attr"]
 hashbrown = ["dep:hashbrown"]
 serde = []


### PR DESCRIPTION
Introduce invocation inspect callback feature where it is possible to have callbacks invoked prior to and after a transaction is sent. This is inspired by `mollusk` (https://github.com/anza-xyz/mollusk/pull/143) and is a prelude to providing the register tracing feature for `LiteSVM` (similar to https://github.com/anza-xyz/mollusk/pull/178).

This feature will help me refactor https://github.com/LiteSVM/litesvm/pull/221 now that https://github.com/LiteSVM/litesvm/pull/246 is ready.

Please provide your feedback particularly to the part which data structures would be of useful to have in the callbacks.