### PR TITLE
Restore Send + Sync bounds on LiteSVM when invocation-inspect-callback feature is enabled

### DIFF
--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -1572,7 +1572,7 @@ where
 }
 
 #[cfg(feature = "invocation-inspect-callback")]
-pub trait InvocationInspectCallback {
+pub trait InvocationInspectCallback: Send + Sync {
     fn before_invocation(
         &self,
         tx: &SanitizedTransaction,


### PR DESCRIPTION
PR (#259) accidentally removed `Send` and `Sync` from the `LiteSVM` structure if the `invocation-inspect-callback` feature is enabled. In this case bring them back by putting a trait bound on the `InvocationInspectCallback` to be `Send` and `Sync`.