### PR TITLE
fix: Check rent fix and assert behaviour seems to match solano

### DIFF
--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -35,7 +35,8 @@ let from = from_keypair.pubkey();
 let to = Address::new_unique();
 
 let mut svm = LiteSVM::new();
-svm.airdrop(&from, 10_000).unwrap();
+svm.airdrop(&from, 1_000_000_000).unwrap();
+svm.airdrop(&to, 1_000_000_000).unwrap();
 
 let instruction = transfer(&from, &to, 64);
 let tx = Transaction::new(
@@ -47,8 +48,8 @@ let tx_res = svm.send_transaction(tx).unwrap();
 
 let from_account = svm.get_account(&from);
 let to_account = svm.get_account(&to);
-assert_eq!(from_account.unwrap().lamports, 4936);
-assert_eq!(to_account.unwrap().lamports, 64);
+assert_eq!(from_account.unwrap().lamports, 999994936);
+assert_eq!(to_account.unwrap().lamports, 1000000064);
 ```
 
 ## Deploying Programs
@@ -1233,22 +1234,20 @@ impl LiteSVM {
                     .get_key_of_account_at_index(index as IndexOfAccount)
                     .map_err(|err| TransactionError::InstructionError(index as u8, err))?;
 
-                if !account.data().is_empty() {
-                    let post_rent_state =
-                        get_account_rent_state(rent, account.lamports(), account.data().len());
-                    let pre_rent_state = self
-                        .accounts
-                        .get_account_ref(pubkey)
-                        .map(|acc| get_account_rent_state(rent, acc.lamports(), acc.data().len()))
-                        .unwrap_or(RentState::Uninitialized);
+                let post_rent_state =
+                    get_account_rent_state(rent, account.lamports(), account.data().len());
+                let pre_rent_state = self
+                    .accounts
+                    .get_account_ref(pubkey)
+                    .map(|acc| get_account_rent_state(rent, acc.lamports(), acc.data().len()))
+                    .unwrap_or(RentState::Uninitialized);
 
-                    check_rent_state_with_account(
-                        &pre_rent_state,
-                        &post_rent_state,
-                        pubkey,
-                        index as IndexOfAccount,
-                    )?;
-                }
+                check_rent_state_with_account(
+                    &pre_rent_state,
+                    &post_rent_state,
+                    pubkey,
+                    index as IndexOfAccount,
+                )?;
             }
         }
         Ok(())

--- a/crates/litesvm/tests/blockhash.rs
+++ b/crates/litesvm/tests/blockhash.rs
@@ -62,6 +62,7 @@ fn test_durable_nonce() {
     let mut svm = LiteSVM::new();
 
     svm.airdrop(&from, 1_000_000_000).unwrap();
+    svm.airdrop(&to, 1_000_000_000).unwrap();
     let create_nonce_ixns = solana_system_interface::instruction::create_nonce_account(
         &from,
         &nonce_kp.pubkey(),

--- a/crates/litesvm/tests/compute_budget.rs
+++ b/crates/litesvm/tests/compute_budget.rs
@@ -3,8 +3,9 @@ use {
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_compute_budget_interface::ComputeBudgetInstruction,
     solana_instruction::error::InstructionError, solana_keypair::Keypair, solana_message::Message,
-    solana_signer::Signer, solana_system_interface::instruction::transfer,
-    solana_transaction::Transaction, solana_transaction_error::TransactionError,
+    solana_native_token::LAMPORTS_PER_SOL, solana_rent::Rent, solana_signer::Signer,
+    solana_system_interface::instruction::transfer, solana_transaction::Transaction,
+    solana_transaction_error::TransactionError,
 };
 
 #[test_log::test]
@@ -16,7 +17,13 @@ fn test_set_compute_budget() {
 
     let mut svm = LiteSVM::new();
     let tx_fee = 5000;
-    svm.airdrop(&from, tx_fee + 100).unwrap();
+    svm.airdrop(
+        &from,
+        svm.get_sysvar::<Rent>().minimum_balance(0) + tx_fee + 100,
+    )
+    .unwrap();
+    svm.airdrop(&to, LAMPORTS_PER_SOL).unwrap();
+
     // need to set the low compute budget after the airdrop tx
     let mut compute_budget = ComputeBudget::new_with_defaults(false, false);
     compute_budget.compute_unit_limit = 10;
@@ -45,7 +52,12 @@ fn test_set_compute_unit_limit() {
     let mut svm = LiteSVM::new();
     let tx_fee = 5000;
 
-    svm.airdrop(&from, tx_fee + 100).unwrap();
+    svm.airdrop(
+        &from,
+        svm.get_sysvar::<Rent>().minimum_balance(0) + tx_fee + 100,
+    )
+    .unwrap();
+    svm.airdrop(&to, LAMPORTS_PER_SOL).unwrap();
 
     let instruction = transfer(&from, &to, 64);
     let tx = Transaction::new(
@@ -86,8 +98,10 @@ fn test_priority_fee_is_charged() {
     let total_fee = base_fee + expected_priority_fee;
     let transfer_amount: u64 = 100;
 
-    let initial_balance = total_fee + transfer_amount;
+    let initial_balance = svm.get_sysvar::<Rent>().minimum_balance(0) + total_fee + transfer_amount;
     svm.airdrop(&from, initial_balance).unwrap();
+    let initial_recipient_balance = LAMPORTS_PER_SOL;
+    svm.airdrop(&to, initial_recipient_balance).unwrap();
 
     let instruction = transfer(&from, &to, transfer_amount);
     let tx = Transaction::new(
@@ -118,12 +132,14 @@ fn test_priority_fee_is_charged() {
     // Note: get_balance returns None if account doesn't exist (0 balance accounts may be pruned)
     let final_balance = svm.get_balance(&from).unwrap_or(0);
     assert_eq!(
-        final_balance, 0,
-        "Fee payer should have 0 balance after paying total_fee ({}) + transfer ({})",
-        total_fee, transfer_amount
+        final_balance, initial_balance - total_fee - transfer_amount,
+        "Fee payer should have 0 balance after paying total_fee ({total_fee}) + transfer ({transfer_amount})"
     );
 
     // Verify recipient received the transfer
     let recipient_balance = svm.get_balance(&to).unwrap();
-    assert_eq!(recipient_balance, transfer_amount);
+    assert_eq!(
+        recipient_balance,
+        initial_recipient_balance + transfer_amount
+    );
 }

--- a/crates/litesvm/tests/fees.rs
+++ b/crates/litesvm/tests/fees.rs
@@ -13,7 +13,7 @@ use {
 };
 
 #[test_log::test]
-fn test_insufficient_funds_for_rent() {
+fn test_fee_payer_insufficient_funds_for_rent() {
     let from_keypair = Keypair::new();
     let from = from_keypair.pubkey();
     let to = Address::new_unique();
@@ -21,6 +21,8 @@ fn test_insufficient_funds_for_rent() {
     let mut svm = LiteSVM::new();
 
     svm.airdrop(&from, svm.get_sysvar::<Rent>().minimum_balance(0))
+        .unwrap();
+    svm.airdrop(&to, svm.get_sysvar::<Rent>().minimum_balance(0))
         .unwrap();
     let instruction = transfer(&from, &to, 1);
     let tx = Transaction::new(

--- a/crates/litesvm/tests/system.rs
+++ b/crates/litesvm/tests/system.rs
@@ -17,9 +17,12 @@ fn system_transfer() {
 
     let mut svm = LiteSVM::new();
     let expected_fee = 5000;
-    svm.airdrop(&from, 100 + expected_fee).unwrap();
+    let original_balance = LAMPORTS_PER_SOL;
+    svm.airdrop(&from, original_balance).unwrap();
+    svm.airdrop(&to, original_balance).unwrap();
 
-    let instruction = transfer(&from, &to, 64);
+    let transfer_amount = 64;
+    let instruction = transfer(&from, &to, transfer_amount);
     let tx = Transaction::new(
         &[&from_keypair],
         Message::new(&[instruction], Some(&from)),
@@ -31,8 +34,14 @@ fn system_transfer() {
     let to_account = svm.get_account(&to);
 
     assert!(tx_res.is_ok());
-    assert_eq!(from_account.unwrap().lamports, 36);
-    assert_eq!(to_account.unwrap().lamports, 64);
+    assert_eq!(
+        from_account.unwrap().lamports,
+        original_balance - expected_fee - transfer_amount
+    );
+    assert_eq!(
+        to_account.unwrap().lamports,
+        original_balance + transfer_amount
+    );
 }
 
 #[test_log::test]
@@ -102,7 +111,7 @@ fn test_airdrop_pubkey() {
     assert_eq!(initial_balance, funding_amount);
 
     let recipient = Address::new_unique();
-    let airdrop_amount = 100_000;
+    let airdrop_amount = LAMPORTS_PER_SOL;
     svm.airdrop(&recipient, airdrop_amount).unwrap();
 
     let after_airdrop = svm.get_balance(&airdrop_pubkey).unwrap();

--- a/crates/litesvm/tests/tx_history.rs
+++ b/crates/litesvm/tests/tx_history.rs
@@ -16,6 +16,7 @@ fn test_tx_history_base_case() {
         .with_blockhash_check(false)
         .with_transaction_history(0);
     svm.airdrop(&from, 10_000_000).unwrap();
+    svm.airdrop(&to, 10_000_000).unwrap();
 
     // Try to create and send two identical transactions
     let instruction = transfer(&from, &to, 100);
@@ -46,6 +47,7 @@ fn test_tx_history_disable_later() {
         .with_sigverify(false)
         .with_blockhash_check(false);
     svm.airdrop(&from, 10_000_000).unwrap();
+    svm.airdrop(&to, 10_000_000).unwrap();
 
     // Try to create and send two identical transactions
     let instruction = transfer(&from, &to, 100);


### PR DESCRIPTION
- Rent exemption checks must happen even when no data, as there is a cost for the account meta
- Add assertion that account is gone and various test fixes