### PR TITLE
fix: update rent.exemption_threshold based on feature gating

### DIFF
--- a/crates/litesvm/tests/parsing.rs
+++ b/crates/litesvm/tests/parsing.rs
@@ -13,7 +13,6 @@ use {
 #[test]
 fn test_inner_instruction_parsing() {
     let mut svm = LiteSVM::new();
-
     let payer_kp = Keypair::new();
     let payer_pk = payer_kp.pubkey();
     svm.airdrop(&payer_pk, 1000000000).unwrap();


### PR DESCRIPTION
From what I understand about [SIMD-0194](https://github.com/anza-xyz/agave/pull/7373), when this feature is activated the rent account's `exemption_threshold` should be 1.0 rather than the default 2.0.