### PR TITLE
Fix precompiles build with solana-rent 3.x

### DIFF
--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -555,7 +555,7 @@ impl LiteSVM {
                 .is_active(&agave_feature_set::deprecate_rent_exemption_threshold::id())
             {
                 rent_account.exemption_threshold = 1.0;
-                rent_account.lamports_per_byte_year = solana_rent::DEFAULT_LAMPORTS_PER_BYTE
+                rent_account.lamports_per_byte_year = solana_rent::DEFAULT_LAMPORTS_PER_BYTE_YEAR
             }
             self.set_sysvar(&rent_account);
         }


### PR DESCRIPTION
 ## Summary

  Fix the `precompiles` feature build when `litesvm` resolves `solana-rent 3.0.0`.

  ## Problem

  `litesvm` declares:

  ```toml
  solana-rent = "3.0"

  but the precompiles path currently uses:

  solana_rent::DEFAULT_LAMPORTS_PER_BYTE

  That constant is not available in solana-rent 3.0.0, so precompiles fails to compile in a valid dependency resolution within the declared supported range.

  ## Why this fix is correct

  The value is assigned to:

  rent_account.lamports_per_byte_year

  so solana_rent::DEFAULT_LAMPORTS_PER_BYTE_YEAR is the correct constant for that field.

  This change keeps the fix narrowly scoped to that one issue and restores compatibility across the declared 3.x support range.