### PR TITLE
chore: Enable `doc_cfg` on docs.rs

### DIFF
--- a/crates/litesvm/Cargo.toml
+++ b/crates/litesvm/Cargo.toml
@@ -8,6 +8,10 @@ rust-version.workspace = true
 repository.workspace = true
 readme = "../../README.md"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 internal-test = []
 invocation-inspect-callback = []

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -284,6 +284,8 @@ much easier.
 
 */
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[cfg(feature = "register-tracing")]
 use crate::register_tracing::DefaultRegisterTracingCallback;
 #[cfg(feature = "precompiles")]

--- a/crates/token/Cargo.toml
+++ b/crates/token/Cargo.toml
@@ -7,6 +7,10 @@ edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = ["dep:spl-token-interface", "dep:solana-account", "dep:solana-rent"]
 token-2022 = ["dep:spl-token-2022-interface"]

--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 mod approve;
 mod approve_checked;
 mod burn;


### PR DESCRIPTION
This enables `all-features` and `doc_cfg` on docs.rs builds for `litesvm` and `litesvm-token`. This improves discoverability of feature-gated features like `new_debuggable`:

<img width="1037" height="348" alt="image" src="https://github.com/user-attachments/assets/92ca5d4e-22ed-4cf9-8bab-3c67abec0fc7" />
