### PR TITLE
feat: add state persistence for LiteSVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,6 +1870,32 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+]
+
+[[package]]
+name = "litesvm-persistence"
+version = "0.10.0"
+dependencies = [
+ "agave-feature-set",
+ "bincode",
+ "crc32fast",
+ "litesvm",
+ "serde",
+ "solana-account",
+ "solana-address 2.2.0",
+ "solana-clock",
+ "solana-compute-budget",
+ "solana-fee-structure",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-message",
+ "solana-signature",
+ "solana-signer",
+ "solana-system-interface 2.0.0",
+ "solana-transaction",
+ "solana-transaction-error",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +1911,32 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+]
+
+[[package]]
+name = "litesvm-persistence"
+version = "0.10.0"
+dependencies = [
+ "agave-feature-set",
+ "bincode",
+ "crc32fast",
+ "litesvm",
+ "serde",
+ "solana-account",
+ "solana-address 2.2.0",
+ "solana-clock",
+ "solana-compute-budget",
+ "solana-fee-structure",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-message",
+ "solana-signature",
+ "solana-signer",
+ "solana-system-interface 2.0.0",
+ "solana-transaction",
+ "solana-transaction-error",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,6 +1278,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +1804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litesvm"
 version = "0.11.0"
 dependencies = [
@@ -1936,6 +1958,7 @@ dependencies = [
  "solana-system-interface 2.0.0",
  "solana-transaction",
  "solana-transaction-error",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 
@@ -2646,6 +2669,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4553,6 +4589,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ solana-vote-interface = "5.0.0"
 spl-associated-token-account-interface = "2.0.0"
 spl-token-2022-interface = "2.0.0"
 spl-token-interface = "2.0.0"
+tempfile = "3"
 test-log = "0.2"
 thiserror = "2.0"
 

--- a/crates/litesvm/Cargo.toml
+++ b/crates/litesvm/Cargo.toml
@@ -20,6 +20,7 @@ hashbrown = ["dep:hashbrown"]
 serde = []
 precompiles = ["dep:agave-precompiles"]
 register-tracing = ["invocation-inspect-callback", "dep:hex", "dep:sha2"]
+persistence-internal = []
 
 [dependencies]
 agave-feature-set.workspace = true

--- a/crates/litesvm/Cargo.toml
+++ b/crates/litesvm/Cargo.toml
@@ -16,6 +16,7 @@ hashbrown = ["dep:hashbrown"]
 serde = []
 precompiles = ["dep:agave-precompiles"]
 register-tracing = ["invocation-inspect-callback", "dep:hex", "dep:sha2"]
+persistence-internal = []
 
 [dependencies]
 agave-feature-set.workspace = true

--- a/crates/litesvm/src/accounts_db.rs
+++ b/crates/litesvm/src/accounts_db.rs
@@ -112,7 +112,7 @@ impl AccountsDb {
         Ok(())
     }
 
-    fn maybe_handle_sysvar_account(
+    pub(crate) fn maybe_handle_sysvar_account(
         &mut self,
         pubkey: Address,
         account: &AccountSharedData,
@@ -228,7 +228,7 @@ impl AccountsDb {
         Ok(())
     }
 
-    fn load_program(
+    pub(crate) fn load_program(
         &self,
         program_account: &AccountSharedData,
     ) -> Result<ProgramCacheEntry, InstructionError> {
@@ -315,6 +315,34 @@ impl AccountsDb {
             error!("Owner does not match any expected loader.");
             Err(InstructionError::IncorrectProgramId)
         }
+    }
+
+    #[cfg(feature = "persistence-internal")]
+    pub(crate) fn load_all_existing_programs(&mut self) -> Result<(), LiteSVMError> {
+        let accounts_snapshot: Vec<(Address, AccountSharedData)> = self
+            .inner
+            .iter()
+            .filter(|(pubkey, acc)| {
+                let is_executable = acc.executable();
+                let is_loadable_program = acc.owner() == &bpf_loader_upgradeable::id()
+                    || acc.owner() == &bpf_loader::id()
+                    || acc.owner() == &bpf_loader_deprecated::id()
+                    || acc.owner() == &loader_v4::id();
+                let in_cache = self.programs_cache.find(pubkey).is_some();
+                is_executable && is_loadable_program && !in_cache
+            })
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+
+        for (program_pubkey, program_acc) in accounts_snapshot {
+            let loaded_program = self
+                .load_program(&program_acc)
+                .map_err(LiteSVMError::Instruction)?;
+            self.programs_cache
+                .replenish(program_pubkey, Arc::new(loaded_program));
+        }
+
+        Ok(())
     }
 
     fn load_lookup_table_addresses(

--- a/crates/litesvm/src/accounts_db.rs
+++ b/crates/litesvm/src/accounts_db.rs
@@ -236,7 +236,11 @@ impl AccountsDb {
 
         let owner = program_account.owner();
         let program_runtime_v1 = self.environments.program_runtime_v1.clone();
-        let slot = self.sysvar_cache.get_clock().unwrap().slot;
+        let slot = self
+            .sysvar_cache
+            .get_clock()
+            .map(|c| c.slot)
+            .unwrap_or(0);
 
         if bpf_loader::check_id(owner) || bpf_loader_deprecated::check_id(owner) {
             ProgramCacheEntry::new(
@@ -319,24 +323,37 @@ impl AccountsDb {
         }
     }
 
+    /// Rebuilds the sysvar cache from account data already present in `self.inner`.
+    #[cfg(feature = "persistence-internal")]
+    pub(crate) fn rebuild_sysvar_cache(&mut self) {
+        self.sysvar_cache.reset();
+        let accounts = &self.inner;
+        self.sysvar_cache
+            .fill_missing_entries(|pubkey, set_sysvar| {
+                if let Some(acc) = accounts.get(pubkey) {
+                    set_sysvar(acc.data())
+                }
+            });
+        if let Ok(clock) = self.sysvar_cache.get_clock() {
+            self.programs_cache.set_slot_for_tests(clock.slot);
+        }
+    }
+
+    /// Scans all accounts for executable programs and loads them into the program cache.
     #[cfg(feature = "persistence-internal")]
     pub(crate) fn load_all_existing_programs(&mut self) -> Result<(), LiteSVMError> {
-        let accounts_snapshot: Vec<(Address, AccountSharedData)> = self
+        let executable_keys: Vec<(Address, AccountSharedData)> = self
             .inner
             .iter()
             .filter(|(pubkey, acc)| {
-                let is_executable = acc.executable();
-                let is_loadable_program = acc.owner() == &bpf_loader_upgradeable::id()
-                    || acc.owner() == &bpf_loader::id()
-                    || acc.owner() == &bpf_loader_deprecated::id()
-                    || acc.owner() == &loader_v4::id();
-                let in_cache = self.programs_cache.find(pubkey).is_some();
-                is_executable && is_loadable_program && !in_cache
+                acc.executable()
+                    && acc.owner() != &native_loader::ID
+                    && self.programs_cache.find(pubkey).is_none()
             })
             .map(|(k, v)| (*k, v.clone()))
             .collect();
 
-        for (program_pubkey, program_acc) in accounts_snapshot {
+        for (program_pubkey, program_acc) in executable_keys {
             let loaded_program = self
                 .load_program(&program_acc)
                 .map_err(LiteSVMError::Instruction)?;

--- a/crates/litesvm/src/accounts_db.rs
+++ b/crates/litesvm/src/accounts_db.rs
@@ -112,7 +112,7 @@ impl AccountsDb {
         Ok(())
     }
 
-    fn maybe_handle_sysvar_account(
+    pub(crate) fn maybe_handle_sysvar_account(
         &mut self,
         pubkey: Address,
         account: &AccountSharedData,
@@ -228,7 +228,7 @@ impl AccountsDb {
         Ok(())
     }
 
-    fn load_program(
+    pub(crate) fn load_program(
         &self,
         program_account: &AccountSharedData,
     ) -> Result<ProgramCacheEntry, InstructionError> {
@@ -317,6 +317,34 @@ impl AccountsDb {
             error!("Owner does not match any expected loader.");
             Err(InstructionError::IncorrectProgramId)
         }
+    }
+
+    #[cfg(feature = "persistence-internal")]
+    pub(crate) fn load_all_existing_programs(&mut self) -> Result<(), LiteSVMError> {
+        let accounts_snapshot: Vec<(Address, AccountSharedData)> = self
+            .inner
+            .iter()
+            .filter(|(pubkey, acc)| {
+                let is_executable = acc.executable();
+                let is_loadable_program = acc.owner() == &bpf_loader_upgradeable::id()
+                    || acc.owner() == &bpf_loader::id()
+                    || acc.owner() == &bpf_loader_deprecated::id()
+                    || acc.owner() == &loader_v4::id();
+                let in_cache = self.programs_cache.find(pubkey).is_some();
+                is_executable && is_loadable_program && !in_cache
+            })
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+
+        for (program_pubkey, program_acc) in accounts_snapshot {
+            let loaded_program = self
+                .load_program(&program_acc)
+                .map_err(LiteSVMError::Instruction)?;
+            self.programs_cache
+                .replenish(program_pubkey, Arc::new(loaded_program));
+        }
+
+        Ok(())
     }
 
     fn load_lookup_table_addresses(

--- a/crates/litesvm/src/history.rs
+++ b/crates/litesvm/src/history.rs
@@ -34,4 +34,24 @@ impl TransactionHistory {
     pub fn check_transaction(&self, signature: &Signature) -> bool {
         self.0.contains_key(signature)
     }
+
+    #[cfg(feature = "persistence-internal")]
+    pub fn inner(&self) -> &IndexMap<Signature, TransactionResult> {
+        &self.0
+    }
+
+    #[cfg(feature = "persistence-internal")]
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
+    #[cfg(feature = "persistence-internal")]
+    pub fn restore_from_entries(
+        &mut self,
+        entries: impl IntoIterator<Item = (Signature, TransactionResult)>,
+    ) {
+        for (sig, result) in entries {
+            self.add_new_transaction(sig, result);
+        }
+    }
 }

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -1783,6 +1783,85 @@ impl InvocationInspectCallback for EmptyInvocationInspectCallback {
     fn after_invocation(&self, _: &LiteSVM, _: &InvokeContext, _enable_register_tracing: bool) {}
 }
 
+#[cfg(feature = "persistence-internal")]
+impl LiteSVM {
+    pub fn airdrop_keypair_bytes(&self) -> &[u8; 64] {
+        &self.airdrop_kp
+    }
+
+    pub fn get_blockhash_check(&self) -> bool {
+        self.blockhash_check
+    }
+
+    pub fn get_fee_structure(&self) -> &FeeStructure {
+        &self.fee_structure
+    }
+
+    pub fn get_log_bytes_limit(&self) -> Option<usize> {
+        self.log_bytes_limit
+    }
+
+    pub fn get_feature_set_ref(&self) -> &FeatureSet {
+        &self.feature_set
+    }
+
+    pub fn transaction_history_entries(
+        &self,
+    ) -> &indexmap::IndexMap<Signature, TransactionResult> {
+        self.history.inner()
+    }
+
+    pub fn get_history_capacity(&self) -> usize {
+        self.history.capacity()
+    }
+
+    pub fn set_fee_structure(&mut self, fee_structure: FeeStructure) {
+        self.fee_structure = fee_structure;
+    }
+
+    pub fn set_latest_blockhash(&mut self, hash: Hash) {
+        self.latest_blockhash = hash;
+    }
+
+    pub fn set_airdrop_keypair(&mut self, kp: [u8; 64]) {
+        self.airdrop_kp = kp;
+    }
+
+    pub fn restore_transaction_history(
+        &mut self,
+        entries: impl IntoIterator<Item = (Signature, TransactionResult)>,
+    ) {
+        self.history.restore_from_entries(entries);
+    }
+
+    pub fn set_account_no_checks(&mut self, address: Address, data: Account) {
+        let shared: AccountSharedData = data.into();
+        if shared.lamports() == 0 {
+            self.accounts.inner.remove(&address);
+        } else {
+            self.accounts.add_account_no_checks(address, shared);
+        }
+    }
+
+    pub fn rebuild_caches(&mut self) -> Result<(), LiteSVMError> {
+        // Phase 1: Rebuild sysvar cache
+        let sysvar_accounts: Vec<(Address, AccountSharedData)> = self
+            .accounts
+            .inner
+            .iter()
+            .filter(|(_, acc)| acc.owner() == &solana_sdk_ids::sysvar::ID)
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+        for (pubkey, account) in sysvar_accounts {
+            self.accounts
+                .maybe_handle_sysvar_account(pubkey, &account)
+                .map_err(LiteSVMError::InvalidSysvarData)?;
+        }
+        // Phase 2: Rebuild program cache
+        self.accounts.load_all_existing_programs()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -1910,6 +1910,85 @@ impl InvocationInspectCallback for EmptyInvocationInspectCallback {
     fn after_invocation(&self, _: &LiteSVM, _: &InvokeContext, _enable_register_tracing: bool) {}
 }
 
+#[cfg(feature = "persistence-internal")]
+impl LiteSVM {
+    pub fn airdrop_keypair_bytes(&self) -> &[u8; 64] {
+        &self.airdrop_kp
+    }
+
+    pub fn get_blockhash_check(&self) -> bool {
+        self.blockhash_check
+    }
+
+    pub fn get_fee_structure(&self) -> &FeeStructure {
+        &self.fee_structure
+    }
+
+    pub fn get_log_bytes_limit(&self) -> Option<usize> {
+        self.log_bytes_limit
+    }
+
+    pub fn get_feature_set_ref(&self) -> &FeatureSet {
+        &self.feature_set
+    }
+
+    pub fn transaction_history_entries(
+        &self,
+    ) -> &indexmap::IndexMap<Signature, TransactionResult> {
+        self.history.inner()
+    }
+
+    pub fn get_history_capacity(&self) -> usize {
+        self.history.capacity()
+    }
+
+    pub fn set_fee_structure(&mut self, fee_structure: FeeStructure) {
+        self.fee_structure = fee_structure;
+    }
+
+    pub fn set_latest_blockhash(&mut self, hash: Hash) {
+        self.latest_blockhash = hash;
+    }
+
+    pub fn set_airdrop_keypair(&mut self, kp: [u8; 64]) {
+        self.airdrop_kp = kp;
+    }
+
+    pub fn restore_transaction_history(
+        &mut self,
+        entries: impl IntoIterator<Item = (Signature, TransactionResult)>,
+    ) {
+        self.history.restore_from_entries(entries);
+    }
+
+    pub fn set_account_no_checks(&mut self, address: Address, data: Account) {
+        let shared: AccountSharedData = data.into();
+        if shared.lamports() == 0 {
+            self.accounts.inner.remove(&address);
+        } else {
+            self.accounts.add_account_no_checks(address, shared);
+        }
+    }
+
+    pub fn rebuild_caches(&mut self) -> Result<(), LiteSVMError> {
+        // Phase 1: Rebuild sysvar cache
+        let sysvar_accounts: Vec<(Address, AccountSharedData)> = self
+            .accounts
+            .inner
+            .iter()
+            .filter(|(_, acc)| acc.owner() == &solana_sdk_ids::sysvar::ID)
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+        for (pubkey, account) in sysvar_accounts {
+            self.accounts
+                .maybe_handle_sysvar_account(pubkey, &account)
+                .map_err(LiteSVMError::InvalidSysvarData)?;
+        }
+        // Phase 2: Rebuild program cache
+        self.accounts.load_all_existing_programs()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -1961,30 +1961,18 @@ impl LiteSVM {
         self.history.restore_from_entries(entries);
     }
 
-    pub fn set_account_no_checks(&mut self, address: Address, data: Account) {
-        let shared: AccountSharedData = data.into();
-        if shared.lamports() == 0 {
-            self.accounts.inner.remove(&address);
-        } else {
-            self.accounts.add_account_no_checks(address, shared);
-        }
+    pub fn set_account_no_checks(&mut self, pubkey: Address, account: AccountSharedData) {
+        self.accounts.add_account_no_checks(pubkey, account);
     }
 
+    /// Rebuilds all derived caches after bulk account insertion.
+    ///
+    /// Order matters: builtins/environments first, then sysvars, then BPF programs.
     pub fn rebuild_caches(&mut self) -> Result<(), LiteSVMError> {
-        // Phase 1: Rebuild sysvar cache
-        let sysvar_accounts: Vec<(Address, AccountSharedData)> = self
-            .accounts
-            .inner
-            .iter()
-            .filter(|(_, acc)| acc.owner() == &solana_sdk_ids::sysvar::ID)
-            .map(|(k, v)| (*k, v.clone()))
-            .collect();
-        for (pubkey, account) in sysvar_accounts {
-            self.accounts
-                .maybe_handle_sysvar_account(pubkey, &account)
-                .map_err(LiteSVMError::InvalidSysvarData)?;
-        }
-        // Phase 2: Rebuild program cache
+        self.reserved_account_keys =
+            Self::reserved_account_keys_for_feature_set(&self.feature_set);
+        self.set_builtins();
+        self.accounts.rebuild_sysvar_cache();
         self.accounts.load_all_existing_programs()
     }
 }

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "litesvm-persistence"
+description = "Disk persistence for LiteSVM state snapshots"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+litesvm = { path = "../litesvm", features = ["persistence-internal", "serde"] }
+bincode.workspace = true
+serde = { workspace = true, features = ["derive"] }
+solana-account = { workspace = true, features = ["serde"] }
+solana-address = { workspace = true, features = ["serde"] }
+solana-hash = { workspace = true, features = ["serde"] }
+solana-fee-structure.workspace = true
+solana-signature = { workspace = true, features = ["serde"] }
+solana-transaction-error = { workspace = true, features = ["serde"] }
+thiserror.workspace = true
+crc32fast = "1"
+agave-feature-set.workspace = true
+solana-compute-budget.workspace = true
+
+[dev-dependencies]
+solana-address = { workspace = true, features = ["serde"] }
+solana-keypair.workspace = true
+solana-signer.workspace = true
+solana-clock.workspace = true
+solana-instruction.workspace = true
+solana-system-interface = { workspace = true, features = ["bincode"] }
+solana-message.workspace = true
+solana-transaction.workspace = true
+solana-compute-budget.workspace = true
+solana-fee-structure.workspace = true
+
+[lints]
+workspace = true

--- a/crates/persistence/Cargo.toml
+++ b/crates/persistence/Cargo.toml
@@ -31,6 +31,7 @@ solana-instruction.workspace = true
 solana-system-interface = { workspace = true, features = ["bincode"] }
 solana-message.workspace = true
 solana-transaction.workspace = true
+tempfile.workspace = true
 solana-compute-budget.workspace = true
 solana-fee-structure.workspace = true
 

--- a/crates/persistence/src/lib.rs
+++ b/crates/persistence/src/lib.rs
@@ -1,11 +1,8 @@
 use {
     agave_feature_set::FeatureSet,
-    litesvm::{
-        types::{FailedTransactionMetadata, TransactionMetadata, TransactionResult},
-        LiteSVM,
-    },
+    litesvm::{types::TransactionResult, LiteSVM},
     serde::{Deserialize, Serialize},
-    solana_account::{Account, AccountSharedData},
+    solana_account::AccountSharedData,
     solana_address::Address,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_fee_structure::FeeStructure,
@@ -35,32 +32,6 @@ pub enum PersistenceError {
     LiteSvm(#[from] litesvm::error::LiteSVMError),
     #[error("Data integrity check failed (expected checksum {expected:#010x}, got {actual:#010x})")]
     ChecksumMismatch { expected: u32, actual: u32 },
-}
-
-/// Serializable wrapper for `TransactionResult` which is
-/// `Result<TransactionMetadata, FailedTransactionMetadata>`.
-#[derive(Serialize, Deserialize)]
-enum TransactionResultState {
-    Ok(TransactionMetadata),
-    Err(FailedTransactionMetadata),
-}
-
-impl From<&TransactionResult> for TransactionResultState {
-    fn from(result: &TransactionResult) -> Self {
-        match result {
-            Ok(meta) => TransactionResultState::Ok(meta.clone()),
-            Err(meta) => TransactionResultState::Err(meta.clone()),
-        }
-    }
-}
-
-impl From<TransactionResultState> for TransactionResult {
-    fn from(state: TransactionResultState) -> Self {
-        match state {
-            TransactionResultState::Ok(meta) => Ok(meta),
-            TransactionResultState::Err(meta) => Err(meta),
-        }
-    }
 }
 
 /// Serializable mirror of `FeeBin` (upstream type lacks serde).
@@ -279,7 +250,7 @@ struct LiteSVMState {
     fee_structure: FeeStructureState,
     active_features: Vec<(Address, u64)>,
     compute_budget: Option<ComputeBudgetState>,
-    history: Vec<(Signature, TransactionResultState)>,
+    history: Vec<(Signature, TransactionResult)>,
     history_capacity: usize,
 }
 
@@ -299,10 +270,10 @@ fn extract_state(svm: &LiteSVM) -> LiteSVMState {
         .map(|(k, v)| (*k, *v))
         .collect();
 
-    let history: Vec<(Signature, TransactionResultState)> = svm
+    let history: Vec<(Signature, TransactionResult)> = svm
         .transaction_history_entries()
         .iter()
-        .map(|(sig, result)| (*sig, TransactionResultState::from(result)))
+        .map(|(sig, result)| (*sig, result.clone()))
         .collect();
 
     LiteSVMState {
@@ -328,32 +299,23 @@ fn restore_from_state(state: LiteSVMState) -> Result<LiteSVM, PersistenceError> 
         feature_set.activate(feature_id, *slot);
     }
 
-    // Build LiteSVM with feature set and builtins.
-    // with_sysvars() initializes the sysvar cache (especially Clock)
-    // because load_program() depends on Clock being available.
-    // The saved sysvar accounts will overwrite these defaults during account loading.
-    //
-    // IMPORTANT: compute_budget must be set BEFORE with_builtins() because
-    // set_builtins() reads self.compute_budget to create ProgramRuntimeEnvironments.
+    // Set scalar config. No with_builtins()/with_sysvars() needed —
+    // rebuild_caches() handles builtins, environments, and sysvar cache
+    // after all accounts are inserted.
     let mut svm = LiteSVM::default().with_feature_set(feature_set);
 
     if let Some(cb_state) = state.compute_budget {
         svm = svm.with_compute_budget(cb_state.into());
     }
 
-    let fee_structure: FeeStructure = state.fee_structure.into();
-
     svm = svm
-        .with_builtins()
-        .with_sysvars()
         .with_sigverify(state.sigverify)
         .with_blockhash_check(state.blockhash_check)
         .with_log_bytes_limit(state.log_bytes_limit)
         .with_transaction_history(state.history_capacity);
 
-    svm.set_fee_structure(fee_structure);
+    svm.set_fee_structure(state.fee_structure.into());
 
-    // Restore airdrop keypair and blockhash.
     let airdrop_kp: [u8; 64] = state
         .airdrop_kp
         .try_into()
@@ -368,24 +330,16 @@ fn restore_from_state(state: LiteSVMState) -> Result<LiteSVM, PersistenceError> 
     svm.set_airdrop_keypair(airdrop_kp);
     svm.set_latest_blockhash(state.latest_blockhash);
 
-    // === TWO-PASS ACCOUNT LOADING ===
-    //
-    // Pass 1: Insert all accounts WITHOUT loading programs into cache.
-    //         This avoids MissingAccount errors when upgradeable programs
-    //         are inserted before their ProgramData accounts.
-    for (address, account_shared_data) in state.accounts {
-        let account: Account = account_shared_data.into();
+    // Pass 1: Insert all accounts without triggering cache updates.
+    for (address, account) in state.accounts {
         svm.set_account_no_checks(address, account);
     }
-    // Pass 2: Rebuild sysvar cache and program cache now that ALL accounts exist.
+
+    // Pass 2: Rebuild builtins, environments, sysvar cache, and program cache.
     svm.rebuild_caches()?;
 
     // Restore transaction history.
-    let history_entries = state
-        .history
-        .into_iter()
-        .map(|(sig, result_state)| (sig, TransactionResult::from(result_state)));
-    svm.restore_transaction_history(history_entries);
+    svm.restore_transaction_history(state.history.into_iter());
 
     Ok(svm)
 }

--- a/crates/persistence/src/lib.rs
+++ b/crates/persistence/src/lib.rs
@@ -1,0 +1,532 @@
+use {
+    agave_feature_set::FeatureSet,
+    litesvm::{
+        types::{FailedTransactionMetadata, TransactionMetadata, TransactionResult},
+        LiteSVM,
+    },
+    serde::{Deserialize, Serialize},
+    solana_account::{Account, AccountSharedData},
+    solana_address::Address,
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_fee_structure::FeeStructure,
+    solana_hash::Hash,
+    solana_signature::Signature,
+    std::{
+        fs,
+        io::{self, BufReader, BufWriter, Read, Write},
+        path::Path,
+    },
+    thiserror::Error,
+};
+
+fn crc32(data: &[u8]) -> u32 {
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(data);
+    hasher.finalize()
+}
+
+#[derive(Error, Debug)]
+pub enum PersistenceError {
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+    #[error("Serialization error: {0}")]
+    Serialize(#[from] bincode::Error),
+    #[error("LiteSVM error: {0}")]
+    LiteSvm(#[from] litesvm::error::LiteSVMError),
+    #[error("Data integrity check failed (expected checksum {expected:#010x}, got {actual:#010x})")]
+    ChecksumMismatch { expected: u32, actual: u32 },
+}
+
+/// Serializable wrapper for `TransactionResult` which is
+/// `Result<TransactionMetadata, FailedTransactionMetadata>`.
+#[derive(Serialize, Deserialize)]
+enum TransactionResultState {
+    Ok(TransactionMetadata),
+    Err(FailedTransactionMetadata),
+}
+
+impl From<&TransactionResult> for TransactionResultState {
+    fn from(result: &TransactionResult) -> Self {
+        match result {
+            Ok(meta) => TransactionResultState::Ok(meta.clone()),
+            Err(meta) => TransactionResultState::Err(meta.clone()),
+        }
+    }
+}
+
+impl From<TransactionResultState> for TransactionResult {
+    fn from(state: TransactionResultState) -> Self {
+        match state {
+            TransactionResultState::Ok(meta) => Ok(meta),
+            TransactionResultState::Err(meta) => Err(meta),
+        }
+    }
+}
+
+/// Serializable mirror of `FeeBin` (upstream type lacks serde).
+#[derive(Serialize, Deserialize)]
+struct FeeBinState {
+    limit: u64,
+    fee: u64,
+}
+
+/// Serializable mirror of `FeeStructure` (upstream type lacks serde).
+#[derive(Serialize, Deserialize)]
+struct FeeStructureState {
+    lamports_per_signature: u64,
+    lamports_per_write_lock: u64,
+    compute_fee_bins: Vec<FeeBinState>,
+}
+
+impl From<&FeeStructure> for FeeStructureState {
+    fn from(fs: &FeeStructure) -> Self {
+        Self {
+            lamports_per_signature: fs.lamports_per_signature,
+            lamports_per_write_lock: fs.lamports_per_write_lock,
+            compute_fee_bins: fs
+                .compute_fee_bins
+                .iter()
+                .map(|bin| FeeBinState {
+                    limit: bin.limit,
+                    fee: bin.fee,
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<FeeStructureState> for FeeStructure {
+    fn from(state: FeeStructureState) -> Self {
+        use solana_fee_structure::FeeBin;
+        FeeStructure {
+            lamports_per_signature: state.lamports_per_signature,
+            lamports_per_write_lock: state.lamports_per_write_lock,
+            compute_fee_bins: state
+                .compute_fee_bins
+                .into_iter()
+                .map(|bin| FeeBin {
+                    limit: bin.limit,
+                    fee: bin.fee,
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Serializable mirror of `ComputeBudget` (upstream type lacks serde).
+#[derive(Serialize, Deserialize)]
+struct ComputeBudgetState {
+    compute_unit_limit: u64,
+    log_64_units: u64,
+    create_program_address_units: u64,
+    invoke_units: u64,
+    max_instruction_stack_depth: usize,
+    max_instruction_trace_length: usize,
+    sha256_base_cost: u64,
+    sha256_byte_cost: u64,
+    sha256_max_slices: u64,
+    max_call_depth: usize,
+    stack_frame_size: usize,
+    log_pubkey_units: u64,
+    cpi_bytes_per_unit: u64,
+    sysvar_base_cost: u64,
+    secp256k1_recover_cost: u64,
+    syscall_base_cost: u64,
+    curve25519_edwards_validate_point_cost: u64,
+    curve25519_edwards_add_cost: u64,
+    curve25519_edwards_subtract_cost: u64,
+    curve25519_edwards_multiply_cost: u64,
+    curve25519_edwards_msm_base_cost: u64,
+    curve25519_edwards_msm_incremental_cost: u64,
+    curve25519_ristretto_validate_point_cost: u64,
+    curve25519_ristretto_add_cost: u64,
+    curve25519_ristretto_subtract_cost: u64,
+    curve25519_ristretto_multiply_cost: u64,
+    curve25519_ristretto_msm_base_cost: u64,
+    curve25519_ristretto_msm_incremental_cost: u64,
+    heap_size: u32,
+    heap_cost: u64,
+    mem_op_base_cost: u64,
+    alt_bn128_addition_cost: u64,
+    alt_bn128_multiplication_cost: u64,
+    alt_bn128_pairing_one_pair_cost_first: u64,
+    alt_bn128_pairing_one_pair_cost_other: u64,
+    big_modular_exponentiation_base_cost: u64,
+    big_modular_exponentiation_cost_divisor: u64,
+    poseidon_cost_coefficient_a: u64,
+    poseidon_cost_coefficient_c: u64,
+    get_remaining_compute_units_cost: u64,
+    alt_bn128_g1_compress: u64,
+    alt_bn128_g1_decompress: u64,
+    alt_bn128_g2_compress: u64,
+    alt_bn128_g2_decompress: u64,
+}
+
+impl From<&ComputeBudget> for ComputeBudgetState {
+    fn from(cb: &ComputeBudget) -> Self {
+        Self {
+            compute_unit_limit: cb.compute_unit_limit,
+            log_64_units: cb.log_64_units,
+            create_program_address_units: cb.create_program_address_units,
+            invoke_units: cb.invoke_units,
+            max_instruction_stack_depth: cb.max_instruction_stack_depth,
+            max_instruction_trace_length: cb.max_instruction_trace_length,
+            sha256_base_cost: cb.sha256_base_cost,
+            sha256_byte_cost: cb.sha256_byte_cost,
+            sha256_max_slices: cb.sha256_max_slices,
+            max_call_depth: cb.max_call_depth,
+            stack_frame_size: cb.stack_frame_size,
+            log_pubkey_units: cb.log_pubkey_units,
+            cpi_bytes_per_unit: cb.cpi_bytes_per_unit,
+            sysvar_base_cost: cb.sysvar_base_cost,
+            secp256k1_recover_cost: cb.secp256k1_recover_cost,
+            syscall_base_cost: cb.syscall_base_cost,
+            curve25519_edwards_validate_point_cost: cb.curve25519_edwards_validate_point_cost,
+            curve25519_edwards_add_cost: cb.curve25519_edwards_add_cost,
+            curve25519_edwards_subtract_cost: cb.curve25519_edwards_subtract_cost,
+            curve25519_edwards_multiply_cost: cb.curve25519_edwards_multiply_cost,
+            curve25519_edwards_msm_base_cost: cb.curve25519_edwards_msm_base_cost,
+            curve25519_edwards_msm_incremental_cost: cb.curve25519_edwards_msm_incremental_cost,
+            curve25519_ristretto_validate_point_cost: cb.curve25519_ristretto_validate_point_cost,
+            curve25519_ristretto_add_cost: cb.curve25519_ristretto_add_cost,
+            curve25519_ristretto_subtract_cost: cb.curve25519_ristretto_subtract_cost,
+            curve25519_ristretto_multiply_cost: cb.curve25519_ristretto_multiply_cost,
+            curve25519_ristretto_msm_base_cost: cb.curve25519_ristretto_msm_base_cost,
+            curve25519_ristretto_msm_incremental_cost: cb
+                .curve25519_ristretto_msm_incremental_cost,
+            heap_size: cb.heap_size,
+            heap_cost: cb.heap_cost,
+            mem_op_base_cost: cb.mem_op_base_cost,
+            alt_bn128_addition_cost: cb.alt_bn128_addition_cost,
+            alt_bn128_multiplication_cost: cb.alt_bn128_multiplication_cost,
+            alt_bn128_pairing_one_pair_cost_first: cb.alt_bn128_pairing_one_pair_cost_first,
+            alt_bn128_pairing_one_pair_cost_other: cb.alt_bn128_pairing_one_pair_cost_other,
+            big_modular_exponentiation_base_cost: cb.big_modular_exponentiation_base_cost,
+            big_modular_exponentiation_cost_divisor: cb.big_modular_exponentiation_cost_divisor,
+            poseidon_cost_coefficient_a: cb.poseidon_cost_coefficient_a,
+            poseidon_cost_coefficient_c: cb.poseidon_cost_coefficient_c,
+            get_remaining_compute_units_cost: cb.get_remaining_compute_units_cost,
+            alt_bn128_g1_compress: cb.alt_bn128_g1_compress,
+            alt_bn128_g1_decompress: cb.alt_bn128_g1_decompress,
+            alt_bn128_g2_compress: cb.alt_bn128_g2_compress,
+            alt_bn128_g2_decompress: cb.alt_bn128_g2_decompress,
+        }
+    }
+}
+
+impl From<ComputeBudgetState> for ComputeBudget {
+    fn from(s: ComputeBudgetState) -> Self {
+        ComputeBudget {
+            compute_unit_limit: s.compute_unit_limit,
+            log_64_units: s.log_64_units,
+            create_program_address_units: s.create_program_address_units,
+            invoke_units: s.invoke_units,
+            max_instruction_stack_depth: s.max_instruction_stack_depth,
+            max_instruction_trace_length: s.max_instruction_trace_length,
+            sha256_base_cost: s.sha256_base_cost,
+            sha256_byte_cost: s.sha256_byte_cost,
+            sha256_max_slices: s.sha256_max_slices,
+            max_call_depth: s.max_call_depth,
+            stack_frame_size: s.stack_frame_size,
+            log_pubkey_units: s.log_pubkey_units,
+            cpi_bytes_per_unit: s.cpi_bytes_per_unit,
+            sysvar_base_cost: s.sysvar_base_cost,
+            secp256k1_recover_cost: s.secp256k1_recover_cost,
+            syscall_base_cost: s.syscall_base_cost,
+            curve25519_edwards_validate_point_cost: s.curve25519_edwards_validate_point_cost,
+            curve25519_edwards_add_cost: s.curve25519_edwards_add_cost,
+            curve25519_edwards_subtract_cost: s.curve25519_edwards_subtract_cost,
+            curve25519_edwards_multiply_cost: s.curve25519_edwards_multiply_cost,
+            curve25519_edwards_msm_base_cost: s.curve25519_edwards_msm_base_cost,
+            curve25519_edwards_msm_incremental_cost: s.curve25519_edwards_msm_incremental_cost,
+            curve25519_ristretto_validate_point_cost: s.curve25519_ristretto_validate_point_cost,
+            curve25519_ristretto_add_cost: s.curve25519_ristretto_add_cost,
+            curve25519_ristretto_subtract_cost: s.curve25519_ristretto_subtract_cost,
+            curve25519_ristretto_multiply_cost: s.curve25519_ristretto_multiply_cost,
+            curve25519_ristretto_msm_base_cost: s.curve25519_ristretto_msm_base_cost,
+            curve25519_ristretto_msm_incremental_cost: s
+                .curve25519_ristretto_msm_incremental_cost,
+            heap_size: s.heap_size,
+            heap_cost: s.heap_cost,
+            mem_op_base_cost: s.mem_op_base_cost,
+            alt_bn128_addition_cost: s.alt_bn128_addition_cost,
+            alt_bn128_multiplication_cost: s.alt_bn128_multiplication_cost,
+            alt_bn128_pairing_one_pair_cost_first: s.alt_bn128_pairing_one_pair_cost_first,
+            alt_bn128_pairing_one_pair_cost_other: s.alt_bn128_pairing_one_pair_cost_other,
+            big_modular_exponentiation_base_cost: s.big_modular_exponentiation_base_cost,
+            big_modular_exponentiation_cost_divisor: s.big_modular_exponentiation_cost_divisor,
+            poseidon_cost_coefficient_a: s.poseidon_cost_coefficient_a,
+            poseidon_cost_coefficient_c: s.poseidon_cost_coefficient_c,
+            get_remaining_compute_units_cost: s.get_remaining_compute_units_cost,
+            alt_bn128_g1_compress: s.alt_bn128_g1_compress,
+            alt_bn128_g1_decompress: s.alt_bn128_g1_decompress,
+            alt_bn128_g2_compress: s.alt_bn128_g2_compress,
+            alt_bn128_g2_decompress: s.alt_bn128_g2_decompress,
+        }
+    }
+}
+
+/// The complete serializable snapshot of LiteSVM state.
+#[derive(Serialize, Deserialize)]
+struct LiteSVMState {
+    accounts: Vec<(Address, AccountSharedData)>,
+    latest_blockhash: Hash,
+    /// Stored as Vec<u8> because serde doesn't natively support [u8; 64].
+    airdrop_kp: Vec<u8>,
+    sigverify: bool,
+    blockhash_check: bool,
+    log_bytes_limit: Option<usize>,
+    fee_structure: FeeStructureState,
+    active_features: Vec<(Address, u64)>,
+    compute_budget: Option<ComputeBudgetState>,
+    history: Vec<(Signature, TransactionResultState)>,
+    history_capacity: usize,
+}
+
+/// Extracts all serializable state from a `LiteSVM` instance.
+fn extract_state(svm: &LiteSVM) -> LiteSVMState {
+    let accounts: Vec<(Address, AccountSharedData)> = svm
+        .accounts_db()
+        .inner
+        .iter()
+        .map(|(k, v)| (*k, v.clone()))
+        .collect();
+
+    let active_features: Vec<(Address, u64)> = svm
+        .get_feature_set_ref()
+        .active()
+        .iter()
+        .map(|(k, v)| (*k, *v))
+        .collect();
+
+    let history: Vec<(Signature, TransactionResultState)> = svm
+        .transaction_history_entries()
+        .iter()
+        .map(|(sig, result)| (*sig, TransactionResultState::from(result)))
+        .collect();
+
+    LiteSVMState {
+        accounts,
+        latest_blockhash: svm.latest_blockhash(),
+        airdrop_kp: svm.airdrop_keypair_bytes().to_vec(),
+        sigverify: svm.get_sigverify(),
+        blockhash_check: svm.get_blockhash_check(),
+        log_bytes_limit: svm.get_log_bytes_limit(),
+        fee_structure: FeeStructureState::from(svm.get_fee_structure()),
+        active_features,
+        compute_budget: svm.get_compute_budget().as_ref().map(ComputeBudgetState::from),
+        history,
+        history_capacity: svm.get_history_capacity(),
+    }
+}
+
+/// Rebuilds a `LiteSVM` instance from a deserialized state snapshot.
+fn restore_from_state(state: LiteSVMState) -> Result<LiteSVM, PersistenceError> {
+    // Reconstruct the feature set from persisted active features.
+    let mut feature_set = FeatureSet::default();
+    for (feature_id, slot) in &state.active_features {
+        feature_set.activate(feature_id, *slot);
+    }
+
+    // Build LiteSVM with feature set and builtins.
+    // with_sysvars() initializes the sysvar cache (especially Clock)
+    // because load_program() depends on Clock being available.
+    // The saved sysvar accounts will overwrite these defaults during account loading.
+    //
+    // IMPORTANT: compute_budget must be set BEFORE with_builtins() because
+    // set_builtins() reads self.compute_budget to create ProgramRuntimeEnvironments.
+    let mut svm = LiteSVM::default().with_feature_set(feature_set);
+
+    if let Some(cb_state) = state.compute_budget {
+        svm = svm.with_compute_budget(cb_state.into());
+    }
+
+    let fee_structure: FeeStructure = state.fee_structure.into();
+
+    svm = svm
+        .with_builtins()
+        .with_sysvars()
+        .with_sigverify(state.sigverify)
+        .with_blockhash_check(state.blockhash_check)
+        .with_log_bytes_limit(state.log_bytes_limit)
+        .with_transaction_history(state.history_capacity);
+
+    svm.set_fee_structure(fee_structure);
+
+    // Restore airdrop keypair and blockhash.
+    let airdrop_kp: [u8; 64] = state
+        .airdrop_kp
+        .try_into()
+        .map_err(|_| {
+            PersistenceError::Serialize(
+                bincode::ErrorKind::Custom(
+                    "airdrop keypair must be exactly 64 bytes".into(),
+                )
+                .into(),
+            )
+        })?;
+    svm.set_airdrop_keypair(airdrop_kp);
+    svm.set_latest_blockhash(state.latest_blockhash);
+
+    // === TWO-PASS ACCOUNT LOADING ===
+    //
+    // Pass 1: Insert all accounts WITHOUT loading programs into cache.
+    //         This avoids MissingAccount errors when upgradeable programs
+    //         are inserted before their ProgramData accounts.
+    for (address, account_shared_data) in state.accounts {
+        let account: Account = account_shared_data.into();
+        svm.set_account_no_checks(address, account);
+    }
+    // Pass 2: Rebuild sysvar cache and program cache now that ALL accounts exist.
+    svm.rebuild_caches()?;
+
+    // Restore transaction history.
+    let history_entries = state
+        .history
+        .into_iter()
+        .map(|(sig, result_state)| (sig, TransactionResult::from(result_state)));
+    svm.restore_transaction_history(history_entries);
+
+    Ok(svm)
+}
+
+/// Stack size for serialization/deserialization threads (64 MB).
+///
+/// Large LiteSVM states with many accounts produce deeply nested bincode
+/// serialization frames that overflow the default 8 MB thread stack.
+const SERDE_STACK_SIZE: usize = 64 * 1024 * 1024;
+
+/// Run a closure on a dedicated thread with a large stack.
+///
+/// Bincode serialization of large Solana account sets recurses deeply,
+/// overflowing the default 8 MB stack. This helper spawns a scoped thread
+/// with [`SERDE_STACK_SIZE`] to handle the load safely.
+fn with_large_stack<F, T>(f: F) -> Result<T, PersistenceError>
+where
+    F: FnOnce() -> T + Send,
+    T: Send,
+{
+    std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .name("litesvm-persistence".into())
+            .stack_size(SERDE_STACK_SIZE)
+            .spawn_scoped(scope, f)
+            .map_err(|e| PersistenceError::Io(io::Error::other(format!("failed to spawn serialization thread: {e}"))))?
+            .join()
+            .map_err(|_| PersistenceError::Io(io::Error::other("serialization thread panicked")))
+    })
+}
+
+/// Saves the current `LiteSVM` state to a file using bincode serialization.
+///
+/// Serialization runs on a dedicated thread with a 64 MB stack to handle
+/// deeply nested Solana types without stack overflow.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use litesvm::LiteSVM;
+/// use litesvm_persistence::{save_to_file, load_from_file};
+///
+/// let mut svm = LiteSVM::new();
+/// // ... set up accounts, deploy programs, etc.
+/// save_to_file(&svm, "snapshot.bin").unwrap();
+///
+/// // Later, restore the state:
+/// let restored_svm = load_from_file("snapshot.bin").unwrap();
+/// ```
+pub fn save_to_file(svm: &LiteSVM, path: impl AsRef<Path>) -> Result<(), PersistenceError> {
+    let state = extract_state(svm);
+    let path = path.as_ref().to_path_buf();
+    with_large_stack(move || -> Result<(), PersistenceError> {
+        // Write to a temp file first, then atomically rename to avoid
+        // leaving a corrupt file if the process crashes mid-write.
+        let tmp_path = path.with_extension("tmp");
+
+        // Serialize to memory, compute checksum, write payload + checksum.
+        let bytes = bincode::serialize(&state)?;
+        let checksum = crc32(&bytes);
+
+        let file = fs::File::create(&tmp_path)?;
+        let mut writer = BufWriter::new(file);
+        writer.write_all(&bytes)?;
+        writer.write_all(&checksum.to_le_bytes())?;
+        writer.flush()?;
+        writer.into_inner().map_err(|e| e.into_error())?.sync_all()?;
+
+        // Atomic rename.
+        fs::rename(&tmp_path, &path)?;
+        Ok(())
+    })?
+}
+
+/// Loads a `LiteSVM` instance from a previously saved state file.
+///
+/// Deserialization runs on a dedicated thread with a 64 MB stack to handle
+/// deeply nested Solana types without stack overflow.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use litesvm_persistence::load_from_file;
+///
+/// let svm = load_from_file("snapshot.bin").unwrap();
+/// // svm is ready to use - all accounts, programs, and config are restored
+/// ```
+pub fn load_from_file(path: impl AsRef<Path>) -> Result<LiteSVM, PersistenceError> {
+    let mut bytes = Vec::new();
+    BufReader::new(fs::File::open(path)?).read_to_end(&mut bytes)?;
+
+    // Verify CRC32 checksum (last 4 bytes).
+    if bytes.len() < 4 {
+        return Err(PersistenceError::Serialize(
+            bincode::ErrorKind::Custom("file too small to contain checksum".into()).into(),
+        ));
+    }
+    let (payload, checksum_bytes) = bytes.split_at(bytes.len() - 4);
+    verify_checksum(payload, checksum_bytes)?;
+
+    let state: LiteSVMState = with_large_stack(move || bincode::deserialize(payload))??;
+    restore_from_state(state)
+}
+
+/// Serializes the current `LiteSVM` state to bytes.
+///
+/// Useful when you want to manage storage yourself (e.g., store in a database
+/// or send over a network). The returned bytes include a trailing CRC32
+/// checksum for integrity verification.
+pub fn to_bytes(svm: &LiteSVM) -> Result<Vec<u8>, PersistenceError> {
+    let state = extract_state(svm);
+    with_large_stack(move || -> Result<Vec<u8>, PersistenceError> {
+        let mut bytes = bincode::serialize(&state)?;
+        let checksum = crc32(&bytes);
+        bytes.extend_from_slice(&checksum.to_le_bytes());
+        Ok(bytes)
+    })?
+}
+
+/// Deserializes a `LiteSVM` instance from bytes.
+///
+/// The bytes must have been produced by [`to_bytes`] and include
+/// a trailing CRC32 checksum.
+pub fn from_bytes(bytes: &[u8]) -> Result<LiteSVM, PersistenceError> {
+    if bytes.len() < 4 {
+        return Err(PersistenceError::Serialize(
+            bincode::ErrorKind::Custom("data too small to contain checksum".into()).into(),
+        ));
+    }
+    let (payload, checksum_bytes) = bytes.split_at(bytes.len() - 4);
+    verify_checksum(payload, checksum_bytes)?;
+
+    let state: LiteSVMState = with_large_stack(|| bincode::deserialize(payload))??;
+    restore_from_state(state)
+}
+
+fn verify_checksum(payload: &[u8], checksum_bytes: &[u8]) -> Result<(), PersistenceError> {
+    let expected = u32::from_le_bytes(checksum_bytes.try_into().unwrap());
+    let actual = crc32(payload);
+    if expected != actual {
+        return Err(PersistenceError::ChecksumMismatch { expected, actual });
+    }
+    Ok(())
+}

--- a/crates/persistence/tests/round_trip.rs
+++ b/crates/persistence/tests/round_trip.rs
@@ -9,16 +9,10 @@ use {
     solana_message::Message,
     solana_signer::Signer,
     solana_transaction::Transaction,
-    std::path::PathBuf,
 };
 
-fn temp_path(name: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join("litesvm_persistence_tests");
-    std::fs::create_dir_all(&dir).unwrap();
-    let path = dir.join(name);
-    // Clean up any leftover file from a previous run.
-    let _ = std::fs::remove_file(&path);
-    path
+fn temp_dir() -> tempfile::TempDir {
+    tempfile::tempdir().unwrap()
 }
 
 #[test]
@@ -29,7 +23,8 @@ fn basic_account_round_trip() {
     account.data = vec![0xAB; 128];
     svm.set_account(addr, account.clone()).unwrap();
 
-    let path = temp_path("basic.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("basic.bin");
     save_to_file(&svm, &path).unwrap();
     let restored = load_from_file(&path).unwrap();
 
@@ -53,7 +48,8 @@ fn multiple_accounts_round_trip() {
         addrs.push(addr);
     }
 
-    let path = temp_path("multi.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let restored = load_from_file(&path).unwrap();
 
@@ -75,7 +71,8 @@ fn sysvar_round_trip() {
         unix_timestamp: 1_700_000_500,
     });
 
-    let path = temp_path("sysvar.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let restored = load_from_file(&path).unwrap();
 
@@ -94,7 +91,8 @@ fn config_round_trip() {
         .with_blockhash_check(false)
         .with_log_bytes_limit(Some(4096));
 
-    let path = temp_path("config.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let restored = load_from_file(&path).unwrap();
 
@@ -110,7 +108,8 @@ fn blockhash_round_trip() {
     svm.expire_blockhash();
     let hash_before = svm.latest_blockhash();
 
-    let path = temp_path("blockhash.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let restored = load_from_file(&path).unwrap();
 
@@ -122,7 +121,8 @@ fn airdrop_keypair_round_trip() {
     let svm = LiteSVM::new().with_builtins().with_sysvars();
     let original_pubkey = svm.airdrop_pubkey();
 
-    let path = temp_path("airdrop_kp.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let restored = load_from_file(&path).unwrap();
 
@@ -151,7 +151,8 @@ fn transaction_history_round_trip() {
     // This will likely fail (no program), but it should still record in history
     let _ = svm.send_transaction(tx);
 
-    let path = temp_path("history.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let restored = load_from_file(&path).unwrap();
 
@@ -180,7 +181,8 @@ fn bytes_round_trip() {
 #[test]
 fn airdrop_works_after_restore() {
     let svm = LiteSVM::new().with_builtins().with_sysvars();
-    let path = temp_path("airdrop_after.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
 
     let mut restored = load_from_file(&path).unwrap();
@@ -201,7 +203,8 @@ fn send_transaction_after_restore() {
     let to = Address::new_unique();
     svm.airdrop(&from_kp.pubkey(), 10_000_000_000).unwrap();
 
-    let path = temp_path("send_after.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let mut restored = load_from_file(&path).unwrap();
 
@@ -229,7 +232,8 @@ fn bpf_program_round_trip() {
     svm.send_transaction(tx).unwrap();
 
     // Save and restore
-    let path = temp_path("bpf.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let mut restored = load_from_file(&path).unwrap();
 
@@ -255,7 +259,8 @@ fn custom_compute_budget_round_trip() {
         .with_builtins()
         .with_sysvars();
 
-    let path = temp_path("custom_budget.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let restored = load_from_file(&path).unwrap();
 
@@ -288,7 +293,8 @@ fn fee_structure_round_trip() {
     let mut svm = LiteSVM::new().with_builtins().with_sysvars();
     svm.set_fee_structure(fee_structure.clone());
 
-    let path = temp_path("fee_structure.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let restored = load_from_file(&path).unwrap();
 
@@ -311,7 +317,8 @@ fn history_capacity_round_trip() {
 
     let original_cap = svm.get_history_capacity();
 
-    let path = temp_path("history_cap.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let restored = load_from_file(&path).unwrap();
 
@@ -334,7 +341,8 @@ fn bpf_program_executes_with_custom_compute_budget() {
     let program_id = Address::new_unique();
     svm.add_program(program_id, program_bytes).unwrap();
 
-    let path = temp_path("bpf_custom_budget.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let mut restored = load_from_file(&path).unwrap();
 
@@ -382,7 +390,8 @@ fn checksum_detects_corruption() {
 #[test]
 fn corrupted_file_returns_checksum_error() {
     let svm = LiteSVM::new().with_builtins().with_sysvars();
-    let path = temp_path("corrupt_file.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
 
     // Corrupt the file on disk.
@@ -411,7 +420,8 @@ fn double_round_trip() {
     svm.set_account(addr, account).unwrap();
 
     // First round trip.
-    let path = temp_path("double_rt.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let mut restored1 = load_from_file(&path).unwrap();
 
@@ -423,7 +433,8 @@ fn double_round_trip() {
     let hash_after = restored1.latest_blockhash();
 
     // Second round trip.
-    let path2 = temp_path("double_rt_2.bin");
+    let dir2 = temp_dir();
+    let path2 = dir2.path().join("snapshot.bin");
     save_to_file(&restored1, &path2).unwrap();
     let restored2 = load_from_file(&path2).unwrap();
 
@@ -439,7 +450,8 @@ fn full_default_round_trip() {
     // sigverify=true, blockhash_check=true — the full default setup.
     let svm = LiteSVM::new();
 
-    let path = temp_path("full_default.bin");
+    let dir = temp_dir();
+    let path = dir.path().join("snapshot.bin");
     save_to_file(&svm, &path).unwrap();
     let mut restored = load_from_file(&path).unwrap();
 

--- a/crates/persistence/tests/round_trip.rs
+++ b/crates/persistence/tests/round_trip.rs
@@ -1,0 +1,460 @@
+use {
+    litesvm::LiteSVM,
+    litesvm_persistence::{from_bytes, load_from_file, save_to_file, to_bytes, PersistenceError},
+    solana_address::Address,
+    solana_clock::Clock,
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_instruction::{AccountMeta, Instruction},
+    solana_keypair::Keypair,
+    solana_message::Message,
+    solana_signer::Signer,
+    solana_transaction::Transaction,
+    std::path::PathBuf,
+};
+
+fn temp_path(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join("litesvm_persistence_tests");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    // Clean up any leftover file from a previous run.
+    let _ = std::fs::remove_file(&path);
+    path
+}
+
+#[test]
+fn basic_account_round_trip() {
+    let mut svm = LiteSVM::new().with_builtins().with_sysvars();
+    let addr = Address::new_unique();
+    let mut account = solana_account::Account::new(42_000, 128, &Address::default());
+    account.data = vec![0xAB; 128];
+    svm.set_account(addr, account.clone()).unwrap();
+
+    let path = temp_path("basic.bin");
+    save_to_file(&svm, &path).unwrap();
+    let restored = load_from_file(&path).unwrap();
+
+    let loaded = restored.get_account(&addr).unwrap();
+    assert_eq!(loaded.lamports, 42_000);
+    assert_eq!(loaded.data, vec![0xAB; 128]);
+}
+
+#[test]
+fn multiple_accounts_round_trip() {
+    let mut svm = LiteSVM::new().with_builtins().with_sysvars();
+    let mut addrs = Vec::new();
+    for i in 0..10u64 {
+        let addr = Address::new_unique();
+        let account = solana_account::Account::new(
+            (i + 1) * 1_000_000,
+            (i as usize + 1) * 32,
+            &Address::default(),
+        );
+        svm.set_account(addr, account).unwrap();
+        addrs.push(addr);
+    }
+
+    let path = temp_path("multi.bin");
+    save_to_file(&svm, &path).unwrap();
+    let restored = load_from_file(&path).unwrap();
+
+    for (i, addr) in addrs.iter().enumerate() {
+        let acc = restored.get_account(addr).unwrap();
+        assert_eq!(acc.lamports, (i as u64 + 1) * 1_000_000);
+        assert_eq!(acc.data.len(), (i + 1) * 32);
+    }
+}
+
+#[test]
+fn sysvar_round_trip() {
+    let mut svm = LiteSVM::new().with_builtins().with_sysvars();
+    svm.set_sysvar(&Clock {
+        slot: 999,
+        epoch_start_timestamp: 1_700_000_000,
+        epoch: 42,
+        leader_schedule_epoch: 43,
+        unix_timestamp: 1_700_000_500,
+    });
+
+    let path = temp_path("sysvar.bin");
+    save_to_file(&svm, &path).unwrap();
+    let restored = load_from_file(&path).unwrap();
+
+    let clock: Clock = restored.get_sysvar();
+    assert_eq!(clock.slot, 999);
+    assert_eq!(clock.unix_timestamp, 1_700_000_500);
+    assert_eq!(clock.epoch, 42);
+}
+
+#[test]
+fn config_round_trip() {
+    let svm = LiteSVM::new()
+        .with_builtins()
+        .with_sysvars()
+        .with_sigverify(false)
+        .with_blockhash_check(false)
+        .with_log_bytes_limit(Some(4096));
+
+    let path = temp_path("config.bin");
+    save_to_file(&svm, &path).unwrap();
+    let restored = load_from_file(&path).unwrap();
+
+    assert_eq!(restored.get_sigverify(), false);
+    assert_eq!(restored.get_blockhash_check(), false);
+    assert_eq!(restored.get_log_bytes_limit(), Some(4096));
+    assert_eq!(restored.get_compute_budget(), svm.get_compute_budget());
+}
+
+#[test]
+fn blockhash_round_trip() {
+    let mut svm = LiteSVM::new().with_builtins().with_sysvars();
+    svm.expire_blockhash();
+    let hash_before = svm.latest_blockhash();
+
+    let path = temp_path("blockhash.bin");
+    save_to_file(&svm, &path).unwrap();
+    let restored = load_from_file(&path).unwrap();
+
+    assert_eq!(restored.latest_blockhash(), hash_before);
+}
+
+#[test]
+fn airdrop_keypair_round_trip() {
+    let svm = LiteSVM::new().with_builtins().with_sysvars();
+    let original_pubkey = svm.airdrop_pubkey();
+
+    let path = temp_path("airdrop_kp.bin");
+    save_to_file(&svm, &path).unwrap();
+    let restored = load_from_file(&path).unwrap();
+
+    assert_eq!(restored.airdrop_pubkey(), original_pubkey);
+}
+
+#[test]
+fn transaction_history_round_trip() {
+    let mut svm = LiteSVM::new()
+        .with_builtins()
+        .with_sysvars()
+        .with_sigverify(false)
+        .with_blockhash_check(false)
+        .with_transaction_history(100);
+
+    let kp = Keypair::new();
+    svm.airdrop(&kp.pubkey(), 1_000_000_000).unwrap();
+
+    let ix = Instruction::new_with_bytes(
+        Address::new_unique(),
+        &[],
+        vec![AccountMeta::new(kp.pubkey(), true)],
+    );
+    let msg = Message::new(&[ix], Some(&kp.pubkey()));
+    let tx = Transaction::new(&[&kp], msg, svm.latest_blockhash());
+    // This will likely fail (no program), but it should still record in history
+    let _ = svm.send_transaction(tx);
+
+    let path = temp_path("history.bin");
+    save_to_file(&svm, &path).unwrap();
+    let restored = load_from_file(&path).unwrap();
+
+    let original_history = svm.transaction_history_entries();
+    let restored_history = restored.transaction_history_entries();
+    assert_eq!(original_history.len(), restored_history.len());
+    for sig in original_history.keys() {
+        assert!(restored_history.contains_key(sig));
+    }
+}
+
+#[test]
+fn bytes_round_trip() {
+    let mut svm = LiteSVM::new().with_builtins().with_sysvars();
+    let addr = Address::new_unique();
+    let account = solana_account::Account::new(123_456, 64, &Address::default());
+    svm.set_account(addr, account).unwrap();
+
+    let bytes = to_bytes(&svm).unwrap();
+    let restored = from_bytes(&bytes).unwrap();
+
+    let loaded = restored.get_account(&addr).unwrap();
+    assert_eq!(loaded.lamports, 123_456);
+}
+
+#[test]
+fn airdrop_works_after_restore() {
+    let svm = LiteSVM::new().with_builtins().with_sysvars();
+    let path = temp_path("airdrop_after.bin");
+    save_to_file(&svm, &path).unwrap();
+
+    let mut restored = load_from_file(&path).unwrap();
+    let recipient = Address::new_unique();
+    restored.airdrop(&recipient, 5_000_000_000).unwrap();
+    assert_eq!(restored.get_balance(&recipient).unwrap(), 5_000_000_000);
+}
+
+#[test]
+fn send_transaction_after_restore() {
+    let mut svm = LiteSVM::new()
+        .with_builtins()
+        .with_sysvars()
+        .with_sigverify(false)
+        .with_blockhash_check(false);
+
+    let from_kp = Keypair::new();
+    let to = Address::new_unique();
+    svm.airdrop(&from_kp.pubkey(), 10_000_000_000).unwrap();
+
+    let path = temp_path("send_after.bin");
+    save_to_file(&svm, &path).unwrap();
+    let mut restored = load_from_file(&path).unwrap();
+
+    let ix = solana_system_interface::instruction::transfer(&from_kp.pubkey(), &to, 1_000_000_000);
+    let msg = Message::new(&[ix], Some(&from_kp.pubkey()));
+    let tx = Transaction::new(&[&from_kp], msg, restored.latest_blockhash());
+    restored.send_transaction(tx).unwrap();
+
+    assert_eq!(restored.get_balance(&to).unwrap(), 1_000_000_000);
+}
+
+#[test]
+fn bpf_program_round_trip() {
+    let mut svm = LiteSVM::new().with_builtins().with_sysvars();
+    let program_bytes = include_bytes!("../../node-litesvm/program_bytes/spl_example_logging.so");
+    let program_id = Address::new_unique();
+    svm.add_program(program_id, program_bytes).unwrap();
+
+    // Execute the program before save
+    let user = Keypair::new();
+    svm.airdrop(&user.pubkey(), 1_000_000_000).unwrap();
+    let ix = Instruction::new_with_bytes(program_id, &[], vec![]);
+    let msg = Message::new(&[ix], Some(&user.pubkey()));
+    let tx = Transaction::new(&[&user], msg, svm.latest_blockhash());
+    svm.send_transaction(tx).unwrap();
+
+    // Save and restore
+    let path = temp_path("bpf.bin");
+    save_to_file(&svm, &path).unwrap();
+    let mut restored = load_from_file(&path).unwrap();
+
+    // Execute the same program on restored instance
+    let user2 = Keypair::new();
+    restored.airdrop(&user2.pubkey(), 1_000_000_000).unwrap();
+    let ix2 = Instruction::new_with_bytes(program_id, &[], vec![]);
+    let msg2 = Message::new(&[ix2], Some(&user2.pubkey()));
+    let tx2 = Transaction::new(&[&user2], msg2, restored.latest_blockhash());
+    restored.send_transaction(tx2).unwrap();
+}
+
+#[test]
+fn custom_compute_budget_round_trip() {
+    let mut budget = ComputeBudget::new_with_defaults(false, false);
+    budget.compute_unit_limit = 500_000;
+    budget.max_call_depth = 128;
+    budget.stack_frame_size = 8192;
+    budget.heap_size = 64 * 1024;
+
+    let svm = LiteSVM::new()
+        .with_compute_budget(budget)
+        .with_builtins()
+        .with_sysvars();
+
+    let path = temp_path("custom_budget.bin");
+    save_to_file(&svm, &path).unwrap();
+    let restored = load_from_file(&path).unwrap();
+
+    let restored_budget = restored.get_compute_budget().unwrap();
+    assert_eq!(restored_budget.compute_unit_limit, 500_000);
+    assert_eq!(restored_budget.max_call_depth, 128);
+    assert_eq!(restored_budget.stack_frame_size, 8192);
+    assert_eq!(restored_budget.heap_size, 64 * 1024);
+}
+
+#[test]
+fn fee_structure_round_trip() {
+    use solana_fee_structure::{FeeBin, FeeStructure};
+
+    let fee_structure = FeeStructure {
+        lamports_per_signature: 10_000,
+        lamports_per_write_lock: 500,
+        compute_fee_bins: vec![
+            FeeBin {
+                limit: 500_000,
+                fee: 0,
+            },
+            FeeBin {
+                limit: 1_400_000,
+                fee: 100,
+            },
+        ],
+    };
+
+    let mut svm = LiteSVM::new().with_builtins().with_sysvars();
+    svm.set_fee_structure(fee_structure.clone());
+
+    let path = temp_path("fee_structure.bin");
+    save_to_file(&svm, &path).unwrap();
+    let restored = load_from_file(&path).unwrap();
+
+    let restored_fs = restored.get_fee_structure();
+    assert_eq!(restored_fs.lamports_per_signature, 10_000);
+    assert_eq!(restored_fs.lamports_per_write_lock, 500);
+    assert_eq!(restored_fs.compute_fee_bins.len(), 2);
+    assert_eq!(restored_fs.compute_fee_bins[0].limit, 500_000);
+    assert_eq!(restored_fs.compute_fee_bins[0].fee, 0);
+    assert_eq!(restored_fs.compute_fee_bins[1].limit, 1_400_000);
+    assert_eq!(restored_fs.compute_fee_bins[1].fee, 100);
+}
+
+#[test]
+fn history_capacity_round_trip() {
+    let svm = LiteSVM::new()
+        .with_builtins()
+        .with_sysvars()
+        .with_transaction_history(500);
+
+    let original_cap = svm.get_history_capacity();
+
+    let path = temp_path("history_cap.bin");
+    save_to_file(&svm, &path).unwrap();
+    let restored = load_from_file(&path).unwrap();
+
+    // Capacity should be preserved exactly (IndexMap may round up from the
+    // requested value, but the persisted value is the actual allocation).
+    assert_eq!(restored.get_history_capacity(), original_cap);
+}
+
+#[test]
+fn bpf_program_executes_with_custom_compute_budget() {
+    let mut budget = ComputeBudget::new_with_defaults(false, false);
+    budget.compute_unit_limit = 2_000_000;
+
+    let mut svm = LiteSVM::new()
+        .with_compute_budget(budget)
+        .with_builtins()
+        .with_sysvars();
+
+    let program_bytes = include_bytes!("../../node-litesvm/program_bytes/spl_example_logging.so");
+    let program_id = Address::new_unique();
+    svm.add_program(program_id, program_bytes).unwrap();
+
+    let path = temp_path("bpf_custom_budget.bin");
+    save_to_file(&svm, &path).unwrap();
+    let mut restored = load_from_file(&path).unwrap();
+
+    // Verify the budget survived
+    assert_eq!(
+        restored.get_compute_budget().unwrap().compute_unit_limit,
+        2_000_000
+    );
+
+    // Verify the program still executes
+    let user = Keypair::new();
+    restored.airdrop(&user.pubkey(), 1_000_000_000).unwrap();
+    let ix = Instruction::new_with_bytes(program_id, &[], vec![]);
+    let msg = Message::new(&[ix], Some(&user.pubkey()));
+    let tx = Transaction::new(&[&user], msg, restored.latest_blockhash());
+    restored.send_transaction(tx).unwrap();
+}
+
+#[test]
+fn load_nonexistent_file_returns_error() {
+    let result = load_from_file("/tmp/litesvm_does_not_exist_12345.bin");
+    assert!(matches!(result, Err(PersistenceError::Io(_))));
+}
+
+#[test]
+fn load_corrupted_data_returns_error() {
+    // Too short to even contain a checksum.
+    let result = from_bytes(&[0xFF, 0xFE, 0xFD]);
+    assert!(matches!(result, Err(PersistenceError::Serialize(_))));
+}
+
+#[test]
+fn checksum_detects_corruption() {
+    let svm = LiteSVM::new().with_builtins().with_sysvars();
+    let mut bytes = to_bytes(&svm).unwrap();
+    // Flip a byte in the payload (not the checksum trailer).
+    bytes[0] ^= 0xFF;
+    let result = from_bytes(&bytes);
+    assert!(
+        matches!(result, Err(PersistenceError::ChecksumMismatch { .. })),
+        "expected ChecksumMismatch"
+    );
+}
+
+#[test]
+fn corrupted_file_returns_checksum_error() {
+    let svm = LiteSVM::new().with_builtins().with_sysvars();
+    let path = temp_path("corrupt_file.bin");
+    save_to_file(&svm, &path).unwrap();
+
+    // Corrupt the file on disk.
+    let mut bytes = std::fs::read(&path).unwrap();
+    bytes[10] ^= 0xFF;
+    std::fs::write(&path, &bytes).unwrap();
+
+    let result = load_from_file(&path);
+    assert!(
+        matches!(result, Err(PersistenceError::ChecksumMismatch { .. })),
+        "expected ChecksumMismatch"
+    );
+}
+
+#[test]
+fn double_round_trip() {
+    // Save -> restore -> modify -> save -> restore
+    let mut svm = LiteSVM::new()
+        .with_builtins()
+        .with_sysvars()
+        .with_sigverify(false)
+        .with_blockhash_check(false);
+
+    let addr = Address::new_unique();
+    let account = solana_account::Account::new(1_000_000, 64, &Address::default());
+    svm.set_account(addr, account).unwrap();
+
+    // First round trip.
+    let path = temp_path("double_rt.bin");
+    save_to_file(&svm, &path).unwrap();
+    let mut restored1 = load_from_file(&path).unwrap();
+
+    // Modify the restored instance.
+    let addr2 = Address::new_unique();
+    let account2 = solana_account::Account::new(2_000_000, 32, &Address::default());
+    restored1.set_account(addr2, account2).unwrap();
+    restored1.expire_blockhash();
+    let hash_after = restored1.latest_blockhash();
+
+    // Second round trip.
+    let path2 = temp_path("double_rt_2.bin");
+    save_to_file(&restored1, &path2).unwrap();
+    let restored2 = load_from_file(&path2).unwrap();
+
+    // Verify both accounts survive.
+    assert_eq!(restored2.get_account(&addr).unwrap().lamports, 1_000_000);
+    assert_eq!(restored2.get_account(&addr2).unwrap().lamports, 2_000_000);
+    assert_eq!(restored2.latest_blockhash(), hash_after);
+}
+
+#[test]
+fn full_default_round_trip() {
+    // LiteSVM::new() includes builtins, sysvars, default programs, lamports,
+    // sigverify=true, blockhash_check=true — the full default setup.
+    let svm = LiteSVM::new();
+
+    let path = temp_path("full_default.bin");
+    save_to_file(&svm, &path).unwrap();
+    let mut restored = load_from_file(&path).unwrap();
+
+    assert_eq!(restored.get_sigverify(), true);
+    assert_eq!(restored.get_blockhash_check(), true);
+
+    // Verify the restored instance is functional: airdrop + system transfer.
+    let from_kp = Keypair::new();
+    let to = Address::new_unique();
+    restored.airdrop(&from_kp.pubkey(), 10_000_000_000).unwrap();
+
+    let ix = solana_system_interface::instruction::transfer(&from_kp.pubkey(), &to, 1_000_000_000);
+    let msg = Message::new(&[ix], Some(&from_kp.pubkey()));
+    let tx = Transaction::new(&[&from_kp], msg, restored.latest_blockhash());
+    restored.send_transaction(tx).unwrap();
+
+    assert_eq!(restored.get_balance(&to).unwrap(), 1_000_000_000);
+}


### PR DESCRIPTION
## Summary

- Adds a `litesvm-persistence` crate that can save and restore full LiteSVM state to/from files or byte buffers using bincode serialization
- Feature-gated `persistence-internal` on litesvm exposes internal getters/setters without polluting the public API
- Two-pass account loading during restore avoids `MissingAccount` errors when upgradeable BPF programs are inserted before their ProgramData accounts
- CRC32 checksums detect file/data corruption, atomic temp-file writes prevent corrupt snapshots on crash

### Persisted state
Accounts, feature set, compute budget, fee structure (including compute_fee_bins), blockhash, airdrop keypair, sigverify/blockhash_check/log_bytes_limit settings, and transaction history with capacity.

### Restore ordering
`with_compute_budget()` is called before `with_builtins()` so runtime environments are created with the correct budget. All accounts are bulk-inserted first (`set_account_no_checks`), then sysvar + program caches are rebuilt in a single `rebuild_caches()` pass.

## Test plan

- [x] 21 round-trip tests covering: basic accounts, multiple accounts, sysvars, config flags, blockhash, airdrop keypair, transaction history, BPF program execution after restore, custom compute budget, custom fee structure, history capacity, bytes API, double round-trip, full default round-trip, error cases (nonexistent file, corrupted data), CRC32 checksum verification (bytes + file)
- [x] 2 doc-tests compile successfully
- [x] All existing litesvm tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)