### PR TITLE
fix: replace unwrap with proper error handling for owner address

### DIFF
--- a/crates/node-litesvm/src/account.rs
+++ b/crates/node-litesvm/src/account.rs
@@ -28,7 +28,8 @@ impl Account {
         Ok(Self(AccountOriginal {
             lamports: bigint_to_u64(&lamports)?,
             data: data.to_vec(),
-            owner: Address::try_from(owner.as_ref()).unwrap(),
+            owner: Address::try_from(owner.as_ref())
+                .map_err(|e| Error::from_reason(e.to_string()))?,
             executable,
             rent_epoch: bigint_to_u64(&rent_epoch)?,
         }))


### PR DESCRIPTION
Using .unwrap() on Address::try_from() caused a panic when an invalid owner bytes were passed from JS, crashing the entire Node.js process. Replaced with .map_err() to propagate the error properly to the caller.