### PR TITLE
test: added coverage for token_program_id

### DIFF
--- a/crates/token/tests/native_mint.rs
+++ b/crates/token/tests/native_mint.rs
@@ -38,3 +38,36 @@ fn test() {
 
     SyncNative::new(svm, &payer_kp, &account_pk).send().unwrap();
 }
+
+#[test]
+fn test_token_program_id() {
+    let svm = &mut LiteSVM::new();
+
+    let payer_kp = Keypair::new();
+    let payer_pk = payer_kp.pubkey();
+
+    svm.airdrop(&payer_pk, LAMPORTS_PER_SOL * 10).unwrap();
+
+    CreateNativeMint::new(svm, &payer_kp)
+        .token_program_id(&spl_token_2022_interface::ID)
+        .send()
+        .unwrap();
+
+    let mint: Mint = get_spl_account(svm, &spl_token_2022_interface::native_mint::ID).unwrap();
+
+    assert_eq!(mint.decimals, 9);
+    assert_eq!(mint.supply, 0);
+    assert!(mint.mint_authority.is_none());
+    assert!(mint.is_initialized);
+    assert_eq!(mint.freeze_authority, None.into());
+
+    let account_pk = CreateAssociatedTokenAccount::new(
+        svm,
+        &payer_kp,
+        &spl_token_2022_interface::native_mint::ID,
+    )
+    .send()
+    .unwrap();
+
+    SyncNative::new(svm, &payer_kp, &account_pk).send().unwrap();
+}


### PR DESCRIPTION
token_program_id: implementation of CreateNativeMint was never hit by cargo tarpaulin. Added test_token_program_id test. 

You don't need the whole test but I didn't want to change the existing test therefore added a new test. If you add .token_program_id(&spl_token_2022_interface::ID) to the existing test it will hit the function. 

The lines 37 and 45 are read as independent by tarpaulin therefore they are not covered. But if they are taken on the same line as their respective "let", that is just move one line above then they get covered.

Thus making these changes takes create_native_mint_2022.rs from 12/15 -> 15/15.