### PR TITLE
test: added coverage for account_kp and token_program_id

### DIFF
--- a/crates/token/tests/one_owner.rs
+++ b/crates/token/tests/one_owner.rs
@@ -4,11 +4,11 @@ use {
         get_spl_account,
         spl_token::{
             instruction::AuthorityType,
-            state::{Account, Mint},
+            state::{Account, AccountState, Mint},
         },
         Approve, ApproveChecked, Burn, BurnChecked, CloseAccount, CreateAccount,
         CreateAssociatedTokenAccount, CreateMint, MintTo, MintToChecked, Revoke, SetAuthority,
-        Transfer, TransferChecked,
+        Transfer, TransferChecked, TOKEN_ID,
     },
     solana_keypair::Keypair,
     solana_native_token::LAMPORTS_PER_SOL,
@@ -165,4 +165,31 @@ fn test() {
         .unwrap();
 
     assert!(svm.get_account(&payer_ata_pk).is_none());
+}
+
+#[test]
+fn test_with_account_keypair() {
+    let svm = &mut LiteSVM::new();
+    let payer_kp = Keypair::new();
+    let payer_pk = payer_kp.pubkey();
+    svm.airdrop(&payer_pk, LAMPORTS_PER_SOL * 10).unwrap();
+
+    let mint_pk = CreateMint::new(svm, &payer_kp).send().unwrap();
+
+    // Generate a specific keypair for the token account
+    let account_kp = Keypair::new();
+    let account_pk = account_kp.pubkey();
+
+    let returned_pk = CreateAccount::new(svm, &payer_kp, &mint_pk)
+        .account_kp(account_kp) // this function was not hit
+        .token_program_id(&TOKEN_ID) // this function was not hit
+        .send()
+        .unwrap();
+
+    // The returned address must match the keypair we provided
+    assert_eq!(returned_pk, account_pk);
+
+    // And the account must exist on-chain
+    let token_account: Account = get_spl_account(svm, &returned_pk).unwrap();
+    assert_eq!(token_account.state, AccountState::Initialized);
 }


### PR DESCRIPTION
account_kp and token_program_id: Implementation of CreateAccount was never hit by cargo tarpaulin. 

Added test_with_account_keypair function in one_owner.rs test file. 

Coverage at 25/35.