### PR TITLE
Add LoaderV4 and include passing tests

### DIFF
--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -357,6 +357,7 @@ use {
     solana_keypair::Keypair,
     solana_last_restart_slot::LastRestartSlot,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
+    solana_loader_v4_interface::state::{LoaderV4State, LoaderV4Status},
     solana_message::{
         inner_instruction::InnerInstructionsList, Message, SanitizedMessage, VersionedMessage,
     },
@@ -372,7 +373,7 @@ use {
     solana_rent::Rent,
     solana_sdk_ids::{
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, config as config_program,
-        native_loader, system_program,
+        loader_v4, native_loader, system_program,
     },
     solana_signature::Signature,
     solana_signer::Signer,
@@ -1004,6 +1005,51 @@ impl LiteSVM {
             self.accounts.add_account_no_checks(program_id, account);
 
             program_len
+        } else if loader_v4::check_id(loader_id) {
+            if self
+                .accounts
+                .programs_cache
+                .find(&loader_v4::id())
+                .is_none()
+            {
+                let builtin = ProgramCacheEntry::new_builtin(
+                    current_slot,
+                    "loader_v4".len(),
+                    solana_loader_v4_program::Entrypoint::vm,
+                );
+                self.accounts
+                    .programs_cache
+                    .replenish(loader_v4::id(), Arc::new(builtin));
+            }
+            if self.accounts.get_account_ref(&loader_v4::id()).is_none() {
+                self.accounts.add_builtin_account(
+                    loader_v4::id(),
+                    crate::utils::create_loadable_account_for_test("loader_v4"),
+                );
+            }
+
+            let metadata_len = LoaderV4State::program_data_offset();
+            let program_len = metadata_len + program_bytes.len();
+
+            let lamports = self.minimum_balance_for_rent_exemption(program_len);
+            let mut account = AccountSharedData::new(lamports, program_len, loader_id);
+            account.set_executable(true);
+
+            let data = account.data_as_mut_slice();
+            let (metadata, program_data) = data.split_at_mut(metadata_len);
+            let (slot, metadata) = metadata.split_at_mut(std::mem::size_of::<u64>());
+            let authority_address_or_next_version = Address::default();
+            let (authority, status) =
+                metadata.split_at_mut(authority_address_or_next_version.as_ref().len());
+
+            slot.copy_from_slice(&current_slot.to_le_bytes());
+            authority.copy_from_slice(authority_address_or_next_version.as_ref());
+            status.copy_from_slice(&(LoaderV4Status::Deployed as u64).to_le_bytes());
+            program_data.copy_from_slice(program_bytes);
+
+            self.accounts.add_account_no_checks(program_id, account);
+
+            program_len
         } else {
             return Err(LiteSVMError::InvalidLoader(format!(
                 "Unsupported loader: {loader_id}"
@@ -1062,6 +1108,7 @@ impl LiteSVM {
     ///
     /// Use `bpf_loader::id()` for BPFLoader2, `bpf_loader_deprecated::id()` for BPFLoader1,
     /// or `bpf_loader_upgradeable::id()` for the upgradeable loader.
+    /// Use `loader_v4::id()` for Loader v4.
     pub fn add_program_with_loader(
         &mut self,
         program_id: impl Into<Address>,

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -1036,16 +1036,10 @@ impl LiteSVM {
             account.set_executable(true);
 
             let data = account.data_as_mut_slice();
-            let (metadata, program_data) = data.split_at_mut(metadata_len);
-            let (slot, metadata) = metadata.split_at_mut(std::mem::size_of::<u64>());
-            let authority_address_or_next_version = Address::default();
-            let (authority, status) =
-                metadata.split_at_mut(authority_address_or_next_version.as_ref().len());
-
-            slot.copy_from_slice(&current_slot.to_le_bytes());
-            authority.copy_from_slice(authority_address_or_next_version.as_ref());
-            status.copy_from_slice(&(LoaderV4Status::Deployed as u64).to_le_bytes());
-            program_data.copy_from_slice(program_bytes);
+            data[..std::mem::size_of::<u64>()].copy_from_slice(&current_slot.to_le_bytes());
+            data[metadata_len - std::mem::size_of::<u64>()..metadata_len]
+                .copy_from_slice(&(LoaderV4Status::Deployed as u64).to_le_bytes());
+            data[metadata_len..].copy_from_slice(program_bytes);
 
             self.accounts.add_account_no_checks(program_id, account);
 

--- a/crates/litesvm/tests/loader_v4.rs
+++ b/crates/litesvm/tests/loader_v4.rs
@@ -1,0 +1,62 @@
+use {
+    litesvm::LiteSVM,
+    solana_account::Account,
+    solana_address::address,
+    solana_instruction::{account_meta::AccountMeta, Instruction},
+    solana_keypair::Keypair,
+    solana_message::Message,
+    solana_sdk_ids::loader_v4,
+    solana_signer::Signer,
+    solana_transaction::Transaction,
+};
+
+fn read_counter_program() -> Vec<u8> {
+    include_bytes!("../../node-litesvm/program_bytes/counter.so").to_vec()
+}
+
+#[test_log::test]
+fn add_program_with_loader_v4_executes_program() {
+    let program_id = address!("GtdambwDgHWrDJdVPBkEHGhCwokqgAoch162teUjJse2");
+    let counter_address = address!("J39wvrFY2AkoAUCke5347RMNk3ditxZfVidoZ7U6Fguf");
+
+    let payer = Keypair::new();
+    let payer_address = payer.pubkey();
+
+    let mut svm = LiteSVM::new();
+    svm.airdrop(&payer_address, 1_000_000_000).unwrap();
+
+    svm.add_program_with_loader(program_id, &read_counter_program(), loader_v4::id())
+        .unwrap();
+
+    svm.set_account(
+        counter_address,
+        Account {
+            lamports: 5,
+            data: vec![0_u8; std::mem::size_of::<u32>()],
+            owner: program_id,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let tx = Transaction::new(
+        &[&payer],
+        Message::new_with_blockhash(
+            &[Instruction {
+                program_id,
+                accounts: vec![AccountMeta::new(counter_address, false)],
+                data: vec![0],
+            }],
+            Some(&payer_address),
+            &svm.latest_blockhash(),
+        ),
+        svm.latest_blockhash(),
+    );
+
+    svm.send_transaction(tx).unwrap();
+
+    assert_eq!(
+        svm.get_account(&counter_address).unwrap().data,
+        1u32.to_le_bytes().to_vec()
+    );
+}


### PR DESCRIPTION
This PR implements support for deploying and testing programs compiled for Loader v4 using  add_program_with_loader .
  
  Refs #351
  
  ## Proposed Changes
  
  1. Loader v4 Support in  add_program_internal :
      • Added support for  loader_v4::id()  in  add_program_internal  inside lib.rs.
      • Initializes the  loader_v4  cache entry and builtin account if they don't already exist.
      • Computes the correct program account data size ( LoaderV4State::program_data_offset()  + the length of the program bytes).
      • Serializes the Loader v4 state metadata header (setting the slot, empty authority address, and status to  LoaderV4Status::Deployed ).
      • Copies the program bytes to the account data at the correct offset.
      • Sets the account as executable and sets its owner to  loader_v4::id() .
  2. Documentation updates:
      • Updated the doc comments for  add_program_with_loader  in lib.rs.
  3. Integration Test:
      • Added a new test file loader_v4.rs that deploys a counter program under  loader_v4::id()  and successfully executes a transaction to increment a counter account.
  

  ## Testing
  
  All tests in the project pass successfully:
  
    cargo test --test loader_v4
