### PR TITLE
Only run the rent check on successful transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Only run the rent check on successful transactions, so a failed transaction keeps its original error instead of `InsufficientFundsForRent` ([#371](https://github.com/LiteSVM/litesvm/pull/371)).
+
 ## [0.13.1] - 2026-06-22
 
 ### Fixed

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -1346,9 +1346,7 @@ impl LiteSVM {
                     self.enable_register_tracing,
                 );
 
-                if let Err(err) = self.check_accounts_rent(tx, &context, &rent) {
-                    tx_result = Err(err);
-                };
+                tx_result = tx_result.and_then(|()| self.check_accounts_rent(tx, &context, &rent));
 
                 (
                     tx_result,

--- a/crates/litesvm/tests/system.rs
+++ b/crates/litesvm/tests/system.rs
@@ -1,12 +1,14 @@
 use {
     litesvm::LiteSVM,
     solana_address::Address,
+    solana_instruction::error::InstructionError,
     solana_keypair::Keypair,
     solana_message::Message,
     solana_native_token::LAMPORTS_PER_SOL,
     solana_signer::Signer,
     solana_system_interface::instruction::{allocate, create_account, transfer},
     solana_transaction::Transaction,
+    solana_transaction_error::TransactionError,
 };
 
 #[test_log::test]
@@ -98,6 +100,65 @@ fn system_allocate_account() {
     svm.send_transaction(tx).unwrap();
 
     assert!(svm.get_account(&new_account).is_none());
+}
+
+#[test_log::test]
+fn test_rent_check_does_not_override_program_error() {
+    let from_keypair = Keypair::new();
+    let from = from_keypair.pubkey();
+    let new_account = Keypair::new();
+    let owner = Address::new_unique();
+
+    let mut svm = LiteSVM::new();
+    svm.airdrop(&from, 10 * LAMPORTS_PER_SOL).unwrap();
+
+    // The first instruction creates an underfunded (rent-paying) data account,
+    // which on its own would trip the post-execution rent check.
+    let ix1 = create_account(&from, &new_account.pubkey(), 1, 10, &owner);
+    // The second instruction creates the same account again and fails with
+    // `SystemError::AccountAlreadyInUse`, unrelated to rent.
+    let ix2 = create_account(&from, &new_account.pubkey(), 1, 10, &owner);
+
+    let tx = Transaction::new(
+        &[&from_keypair, &new_account],
+        Message::new(&[ix1, ix2], Some(&from)),
+        svm.latest_blockhash(),
+    );
+    let tx_res = svm.send_transaction(tx);
+
+    // The failed transaction must surface its original instruction error, not
+    // `TransactionError::InsufficientFundsForRent` from the rent check on
+    // account state that is discarded anyway.
+    assert_eq!(
+        tx_res.unwrap_err().err,
+        TransactionError::InstructionError(1, InstructionError::Custom(0))
+    );
+}
+
+#[test_log::test]
+fn test_rent_check_still_fails_successful_transaction() {
+    let from_keypair = Keypair::new();
+    let from = from_keypair.pubkey();
+    let new_account = Keypair::new();
+    let owner = Address::new_unique();
+
+    let mut svm = LiteSVM::new();
+    svm.airdrop(&from, 10 * LAMPORTS_PER_SOL).unwrap();
+
+    // A single instruction that succeeds but leaves the new account
+    // rent-paying must still fail the post-execution rent check.
+    let instruction = create_account(&from, &new_account.pubkey(), 1, 10, &owner);
+    let tx = Transaction::new(
+        &[&from_keypair, &new_account],
+        Message::new(&[instruction], Some(&from)),
+        svm.latest_blockhash(),
+    );
+    let tx_res = svm.send_transaction(tx);
+
+    assert_eq!(
+        tx_res.unwrap_err().err,
+        TransactionError::InsufficientFundsForRent { account_index: 1 }
+    );
 }
 
 #[test_log::test]


### PR DESCRIPTION
Fixes #365.

The post-execution rent check ran even when the transaction had already failed, replacing the original program error with `InsufficientFundsForRent`. It now runs only when the transaction otherwise succeeded, so a failed transaction keeps its real error.

Added regression tests for both directions: a failed transaction keeps its instruction error, and a successful transaction that leaves an account rent-paying still fails the rent check.
