### PR TITLE
Validate account locks even when sigverify is off

### DIFF
--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -1119,6 +1119,17 @@ impl LiteSVM {
         res.inspect_err(|_| {
             log::error!("Transaction sanitization failed");
         })
+        .and_then(|tx| {
+            // The bank enforces the account-lock limit on every transaction
+            // independently of signature verification, so a transaction over
+            // the limit can never execute on a real cluster. Validate it in
+            // the no-verify path too, rather than only alongside sigverify.
+            SanitizedTransaction::validate_account_locks(
+                tx.message(),
+                get_transaction_account_lock_limit(self),
+            )?;
+            Ok(tx)
+        })
     }
 
     fn sanitize_transaction_no_verify(
@@ -1150,10 +1161,6 @@ impl LiteSVM {
         let tx = self.sanitize_transaction_no_verify_inner(tx)?;
 
         tx.verify()?;
-        SanitizedTransaction::validate_account_locks(
-            tx.message(),
-            get_transaction_account_lock_limit(self),
-        )?;
 
         Ok(tx)
     }

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -1120,10 +1120,6 @@ impl LiteSVM {
             log::error!("Transaction sanitization failed");
         })
         .and_then(|tx| {
-            // The bank enforces the account-lock limit on every transaction
-            // independently of signature verification, so a transaction over
-            // the limit can never execute on a real cluster. Validate it in
-            // the no-verify path too, rather than only alongside sigverify.
             SanitizedTransaction::validate_account_locks(
                 tx.message(),
                 get_transaction_account_lock_limit(self),

--- a/crates/litesvm/tests/account_locks.rs
+++ b/crates/litesvm/tests/account_locks.rs
@@ -104,3 +104,45 @@ fn test_too_many_account_locks() {
         "Expected TooManyAccountLocks error when transaction has more than 64 accounts"
     );
 }
+
+#[test]
+fn test_too_many_account_locks_without_sigverify() {
+    use solana_system_interface::instruction::transfer;
+
+    // The bank enforces the account-lock limit regardless of signature
+    // verification, so disabling sigverify must not skip it.
+    let mut svm = LiteSVM::new().with_sigverify(false);
+    let payer_kp = Keypair::new();
+    let payer_pk = payer_kp.pubkey();
+    svm.airdrop(&payer_pk, 1_000_000_000_000).unwrap();
+
+    let compute_budget_ix =
+        solana_compute_budget_interface::ComputeBudgetInstruction::set_compute_unit_limit(
+            1_000_000,
+        );
+    let mut instructions: Vec<Instruction> = vec![compute_budget_ix];
+    for _ in 0..MAX_TX_ACCOUNT_LOCKS {
+        let recipient = Address::new_unique();
+        instructions.push(transfer(&payer_pk, &recipient, 1_000_000));
+    }
+
+    let tx = Transaction::new(
+        &[&payer_kp],
+        Message::new(&instructions, Some(&payer_pk)),
+        svm.latest_blockhash(),
+    );
+
+    let sim = svm.simulate_transaction(tx.clone());
+    assert_eq!(
+        sim.unwrap_err().err,
+        TransactionError::TooManyAccountLocks,
+        "simulate_transaction with sigverify disabled must still enforce the account-lock limit"
+    );
+
+    let result = svm.send_transaction(tx);
+    assert_eq!(
+        result.unwrap_err().err,
+        TransactionError::TooManyAccountLocks,
+        "send_transaction with sigverify disabled must still enforce the account-lock limit"
+    );
+}

--- a/crates/litesvm/tests/account_locks.rs
+++ b/crates/litesvm/tests/account_locks.rs
@@ -109,8 +109,6 @@ fn test_too_many_account_locks() {
 fn test_too_many_account_locks_without_sigverify() {
     use solana_system_interface::instruction::transfer;
 
-    // The bank enforces the account-lock limit regardless of signature
-    // verification, so disabling sigverify must not skip it.
     let mut svm = LiteSVM::new().with_sigverify(false);
     let payer_kp = Keypair::new();
     let payer_pk = payer_kp.pubkey();


### PR DESCRIPTION
`validate_account_locks` only runs in `sanitize_transaction_inner`, i.e. the path used when sigverify is enabled. With `.with_sigverify(false)`, a transaction locking more than `MAX_TX_ACCOUNT_LOCKS` (64) accounts executes normally.

An RPC `simulateTransaction` returns `TooManyAccountLocks` for an over-limit transaction whether or not `sigVerify` is set. So LiteSVM currently executes transactions with sigverify off that can never land on a real cluster.

The fix moves the `validate_account_locks` call into `sanitize_transaction_no_verify_inner`, which both sanitize paths go through. Added a regression test next to the existing lock tests: a >64-lock transaction with sigverify disabled, expecting `TooManyAccountLocks` from both `simulate_transaction` and `send_transaction`.

Note, this changes behaviour for anyone who relied on simulating over-limit transactions with sigverify off, though those simulations produce results that can't occur on chain. Change could be gated if this is an issue