### PR TITLE
make epoch stakes configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           export PATH="$GITHUB_PATH:$PATH"
 
       - name: Build test programs
-        run: cd crates/litesvm/test_programs && cargo build-sbf
+        run: cd crates/litesvm/test_programs && cargo build-sbf -- --locked
 
       - name: Run tests
         run: cargo test --features precompiles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
 
       - name: Install Solana CLI
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.3/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v4.1.2/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
           export PATH="$GITHUB_PATH:$PATH"
 
       - name: Build test programs
-        run: cd crates/litesvm/test_programs && cargo build-sbf -- --locked
+        run: cd crates/litesvm/test_programs && cargo build-sbf
 
       - name: Run tests
         run: cargo test --features precompiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Add `LiteSVM::{set_epoch_stake, set_epoch_stakes, epoch_total_stake, epoch_stake}` so tests can configure values returned by the `sol_get_epoch_stake` syscall (previously always `0`). The per-vote map is the source of truth; the cluster total is maintained as its checked sum (overwrites adjust the total, overflow returns `LiteSVMError::EpochStakeOverflow`).
+
 ## [0.14.0] - 2026-07-13
 
 ### Added

--- a/crates/litesvm/Cargo.toml
+++ b/crates/litesvm/Cargo.toml
@@ -107,6 +107,7 @@ criterion.workspace = true
 ed25519-dalek.workspace = true
 libsecp256k1.workspace = true
 serde.workspace = true
+solana-address.workspace = true
 solana-clock.workspace = true
 solana-compute-budget-interface.workspace = true
 solana-ed25519-program.workspace = true
@@ -116,6 +117,7 @@ solana-program-pack.workspace = true
 solana-secp256k1-program = { workspace = true, features = ["bincode"] }
 solana-signer.workspace = true
 solana-stake-interface.workspace = true
+solana-svm-callback = { workspace = true, features = ["agave-unstable-api"] }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 spl-associated-token-account-interface.workspace = true
 spl-token-interface.workspace = true

--- a/crates/litesvm/src/callback.rs
+++ b/crates/litesvm/src/callback.rs
@@ -1,28 +1,36 @@
-use {crate::LiteSVM, solana_svm_callback::InvokeContextCallback};
+use {crate::LiteSVM, solana_address::Address, solana_svm_callback::InvokeContextCallback};
 #[cfg(feature = "precompiles")]
 use {
     agave_precompiles::{get_precompile, is_precompile},
-    solana_address::Address,
     solana_precompile_error::PrecompileError,
 };
 
-#[cfg(not(feature = "precompiles"))]
-impl InvokeContextCallback for LiteSVM {}
-
-#[cfg(feature = "precompiles")]
 impl InvokeContextCallback for LiteSVM {
+    fn get_epoch_stake(&self) -> u64 {
+        self.epoch_total_stake
+    }
+
+    fn get_epoch_stake_for_vote_account(&self, vote_address: &Address) -> u64 {
+        self.epoch_vote_stakes
+            .get(vote_address)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    #[cfg(feature = "precompiles")]
     fn is_precompile(&self, program_id: &Address) -> bool {
         is_precompile(program_id, |feature_id: &Address| {
             self.feature_set.is_active(feature_id)
         })
     }
 
+    #[cfg(feature = "precompiles")]
     fn process_precompile(
         &self,
         program_id: &Address,
         data: &[u8],
         instruction_datas: Vec<&[u8]>,
-    ) -> Result<(), solana_precompile_error::PrecompileError> {
+    ) -> Result<(), PrecompileError> {
         if let Some(precompile) = get_precompile(program_id, |feature_id: &Address| {
             self.feature_set.is_active(feature_id)
         }) {

--- a/crates/litesvm/src/error.rs
+++ b/crates/litesvm/src/error.rs
@@ -34,4 +34,6 @@ pub enum LiteSVMError {
     InvalidLoader(String),
     #[error("{0}")]
     ProgramLoad(String),
+    #[error("Epoch stake arithmetic overflow")]
+    EpochStakeOverflow,
 }

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -310,6 +310,8 @@ much easier.
 
 #[cfg(feature = "register-tracing")]
 use crate::register_tracing::DefaultRegisterTracingCallback;
+#[cfg(feature = "hashbrown")]
+use hashbrown::{hash_map::Entry, HashMap};
 #[cfg(feature = "persistence-internal")]
 use indexmap::IndexMap;
 #[cfg(feature = "precompiles")]
@@ -320,6 +322,8 @@ use qualifier_attr::qualifiers;
 use solana_sysvar::recent_blockhashes::IterItem;
 #[allow(deprecated)]
 use solana_sysvar::{fees::Fees, recent_blockhashes::RecentBlockhashes};
+#[cfg(not(feature = "hashbrown"))]
+use std::collections::{hash_map::Entry, HashMap};
 use {
     crate::{
         accounts_db::AccountsDb,
@@ -450,6 +454,8 @@ pub struct LiteSVM {
     fee_structure: FeeStructure,
     log_bytes_limit: Option<usize>,
     custom_syscalls: Vec<(String, BuiltinFunctionRegisterer)>,
+    epoch_total_stake: u64,
+    epoch_vote_stakes: HashMap<Address, u64>,
     /// The callback which can be used to inspect invoke_context
     /// and extract low-level information such as bpf traces, transaction
     /// context, detailed timings, etc.
@@ -493,6 +499,8 @@ impl LiteSVM {
             fee_structure: FeeStructure::default(),
             log_bytes_limit: Some(10_000),
             custom_syscalls: Vec::new(),
+            epoch_total_stake: 0,
+            epoch_vote_stakes: HashMap::new(),
             #[cfg(feature = "invocation-inspect-callback")]
             enable_register_tracing: _enable_register_tracing,
             #[cfg(feature = "invocation-inspect-callback")]
@@ -826,6 +834,97 @@ impl LiteSVM {
     /// Sets all information associated with the account of the provided pubkey.
     pub fn set_account(&mut self, address: Address, data: Account) -> Result<(), LiteSVMError> {
         self.accounts.add_account(address, data.into())
+    }
+
+    /// Sets the active stake for `vote_account` returned by
+    /// `sol_get_epoch_stake(vote_account)`.
+    ///
+    /// Updates the cluster total (`sol_get_epoch_stake(null)`) by replacing any
+    /// previous stake for this vote: `total = total - previous + stake`, using
+    /// checked arithmetic. Setting `stake` to `0` removes the vote from the map.
+    ///
+    /// Returns [`LiteSVMError::EpochStakeOverflow`] if the new total would
+    /// overflow `u64`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use {litesvm::LiteSVM, solana_address::Address};
+    ///
+    /// let mut svm = LiteSVM::new();
+    /// let vote = Address::new_unique();
+    /// svm.set_epoch_stake(vote, 500).unwrap();
+    /// svm.set_epoch_stake(vote, 200).unwrap(); // overwrite adjusts total
+    /// assert_eq!(svm.epoch_stake(&vote), 200);
+    /// assert_eq!(svm.epoch_total_stake(), 200);
+    /// ```
+    pub fn set_epoch_stake(
+        &mut self,
+        vote_account: Address,
+        stake: u64,
+    ) -> Result<(), LiteSVMError> {
+        match self.epoch_vote_stakes.entry(vote_account) {
+            Entry::Occupied(mut entry) => {
+                let previous = *entry.get();
+                self.epoch_total_stake = self
+                    .epoch_total_stake
+                    .checked_sub(previous)
+                    .and_then(|total| total.checked_add(stake))
+                    .ok_or(LiteSVMError::EpochStakeOverflow)?;
+                if stake == 0 {
+                    entry.remove();
+                } else {
+                    *entry.get_mut() = stake;
+                }
+            }
+            Entry::Vacant(entry) => {
+                if stake != 0 {
+                    self.epoch_total_stake = self
+                        .epoch_total_stake
+                        .checked_add(stake)
+                        .ok_or(LiteSVMError::EpochStakeOverflow)?;
+                    entry.insert(stake);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Replaces all per-vote epoch stakes. The cluster total becomes the
+    /// checked sum of `stakes` (zero entries are dropped).
+    ///
+    /// Returns [`LiteSVMError::EpochStakeOverflow`] if the sum overflows `u64`.
+    pub fn set_epoch_stakes(
+        &mut self,
+        stakes: impl IntoIterator<Item = (Address, u64)>,
+    ) -> Result<(), LiteSVMError> {
+        let mut total = 0u64;
+        let mut map = HashMap::new();
+        for (vote_account, stake) in stakes {
+            if stake == 0 {
+                continue;
+            }
+            total = total
+                .checked_add(stake)
+                .ok_or(LiteSVMError::EpochStakeOverflow)?;
+            map.insert(vote_account, stake);
+        }
+        self.epoch_vote_stakes = map;
+        self.epoch_total_stake = total;
+        Ok(())
+    }
+
+    /// Returns the total epoch stake (sum of all configured vote stakes).
+    pub fn epoch_total_stake(&self) -> u64 {
+        self.epoch_total_stake
+    }
+
+    /// Returns the configured epoch stake for `vote_account`, or `0` if unset.
+    pub fn epoch_stake(&self, vote_account: &Address) -> u64 {
+        self.epoch_vote_stakes
+            .get(vote_account)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// **⚠️ ADVANCED USE ONLY ⚠️**

--- a/crates/litesvm/test_programs/Cargo.lock
+++ b/crates/litesvm/test_programs/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -94,7 +94,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -138,6 +138,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -211,6 +245,12 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -306,6 +346,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,18 +362,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -374,7 +420,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -389,6 +435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,7 +452,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc3397241392f5756925029acaa8515dc70fcbe3d8059d4885d7d6533baf64fd"
 dependencies = [
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
  "solana-program-error",
  "solana-program-memory",
 ]
@@ -411,24 +463,26 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
 ]
 
 [[package]]
 name = "solana-address"
-version = "2.0.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37320fd2945c5d654b2c6210624a52d66c3f1f73b653ed211ab91a703b35bdd"
+checksum = "39c93e262f671bf402e1040e4a7e40b05d81da5956c7681948c975a0997517bb"
 dependencies = [
  "borsh",
  "five8",
  "five8_const",
  "serde",
+ "sha2-const-stable",
  "solana-atomic-u64",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.1.0",
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
+ "wincode",
 ]
 
 [[package]]
@@ -480,6 +534,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
+name = "solana-define-syscall"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
+
+[[package]]
 name = "solana-epoch-rewards"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +564,16 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-epoch-stake"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027e6d0b9e7daac5b2ac7c3f9ca1b727861121d9ef05084cf435ff736051e7c2"
+dependencies = [
+ "solana-define-syscall 5.1.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
@@ -551,7 +621,7 @@ dependencies = [
  "serde",
  "solana-define-syscall 4.0.1",
  "solana-instruction-error",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
@@ -595,7 +665,7 @@ dependencies = [
  "solana-account-info",
  "solana-define-syscall 4.0.1",
  "solana-program-error",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
@@ -627,11 +697,11 @@ dependencies = [
 
 [[package]]
 name = "solana-pubkey"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f7104d456b58e1418c21a8581e89810278d1190f70f27ece7fc0b2c9282a57"
+checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
 dependencies = [
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
 ]
 
 [[package]]
@@ -659,7 +729,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
 dependencies = [
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
 ]
 
 [[package]]
@@ -671,7 +741,7 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -744,7 +814,7 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-memory",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
  "solana-rent",
  "solana-sdk-ids",
  "solana-sdk-macro",
@@ -759,15 +829,32 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
  "solana-sdk-ids",
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.110"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -796,6 +883,37 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "test-program-epoch-stake"
+version = "0.0.0"
+dependencies = [
+ "solana-account-info",
+ "solana-epoch-stake",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -860,6 +978,31 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wincode"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror",
+ "wincode-derive",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "windows-link"

--- a/crates/litesvm/test_programs/Cargo.lock
+++ b/crates/litesvm/test_programs/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -25,34 +25,26 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "borsh"
-version = "1.5.7"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.7"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -82,20 +74,26 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cfg-if"
@@ -105,9 +103,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "counter"
@@ -118,26 +116,7 @@ dependencies = [
  "solana-msg",
  "solana-program-entrypoint",
  "solana-program-error",
- "solana-pubkey 3.0.0",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
+ "solana-pubkey",
 ]
 
 [[package]]
@@ -175,16 +154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,7 +166,7 @@ dependencies = [
  "solana-account-info",
  "solana-program-entrypoint",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
 ]
 
 [[package]]
@@ -231,20 +200,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "ident_case"
@@ -254,9 +213,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -270,9 +229,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "litesvm-clock-example"
@@ -282,7 +241,7 @@ dependencies = [
  "solana-clock",
  "solana-program-entrypoint",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
  "solana-sysvar",
 ]
 
@@ -297,15 +256,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-traits"
@@ -318,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "parking_lot"
@@ -353,9 +312,9 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -395,9 +354,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -405,65 +364,39 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha2-const-stable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "solana-account-info"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3397241392f5756925029acaa8515dc70fcbe3d8059d4885d7d6533baf64fd"
+checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
- "solana-address 2.6.1",
+ "solana-address",
  "solana-program-error",
  "solana-program-memory",
-]
-
-[[package]]
-name = "solana-address"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
-dependencies = [
- "solana-address 2.6.1",
 ]
 
 [[package]]
@@ -476,32 +409,32 @@ dependencies = [
  "five8",
  "five8_const",
  "serde",
- "sha2-const-stable",
+ "serde_derive",
  "solana-atomic-u64",
  "solana-define-syscall 5.1.0",
  "solana-program-error",
  "solana-sanitize",
- "solana-sha256-hasher",
  "wincode",
 ]
 
 [[package]]
 name = "solana-atomic-u64"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a933ff1e50aff72d02173cfcd7511bd8540b027ee720b75f353f594f834216d0"
+checksum = "085db4906d89324cef2a30840d59eaecf3d4231c560ec7c9f6614a93c652f501"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "solana-clock"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb62e9381182459a4520b5fe7fb22d423cae736239a6427fc398a88743d0ed59"
+checksum = "f0acdace90d96e2c9e70d681465b4fe888b6bcf27c354ae9774e9f8a3b72923d"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-get-sysvar",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -509,23 +442,17 @@ dependencies = [
 
 [[package]]
 name = "solana-cpi"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16238feb63d1cbdf915fb287f29ef7a7ebf81469bd6214f8b72a53866b593f8f"
+checksum = "4dea26709d867aada85d0d3617db0944215c8bb28d3745b912de7db13a23280c"
 dependencies = [
  "solana-account-info",
- "solana-define-syscall 3.0.0",
+ "solana-define-syscall 4.0.1",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
  "solana-stable-layout",
 ]
-
-[[package]]
-name = "solana-define-syscall"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
 
 [[package]]
 name = "solana-define-syscall"
@@ -541,13 +468,14 @@ checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
 
 [[package]]
 name = "solana-epoch-rewards"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b319a4ed70390af911090c020571f0ff1f4ec432522d05ab89f5c08080381995"
+checksum = "daf7eb4986b0b1d6f562b21f75a836f1a6df6e00c275efcef50aab5c144dc59e"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 3.1.0",
+ "solana-get-sysvar",
+ "solana-hash",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -555,12 +483,14 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-schedule"
-version = "3.0.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5481e72cc4d52c169db73e4c0cd16de8bc943078aac587ec4817a75cc6388f"
+checksum = "8116e6ffa6002237d5ab5edcbda17f9ba66b6742c45a89c9fb40a94dbacd4c1d"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-get-sysvar",
+ "solana-program-error",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -573,14 +503,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "027e6d0b9e7daac5b2ac7c3f9ca1b727861121d9ef05084cf435ff736051e7c2"
 dependencies = [
  "solana-define-syscall 5.1.0",
- "solana-pubkey 4.2.0",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-fee-calculator"
-version = "3.0.0"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a73cc03ca4bed871ca174558108835f8323e85917bb38b9c81c7af2ab853efe"
+checksum = "ef67f01cc6a0c72e99a08d0d484683f995de4c80e9568728fa77d1537f9b7e09"
 dependencies = [
  "log",
  "serde",
@@ -588,47 +518,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-hash"
-version = "3.1.0"
+name = "solana-get-sysvar"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
+checksum = "ef3bc859fc036ed490146793557386cbfae614ebba4adc704c37d94350824ed4"
 dependencies = [
- "solana-hash 4.0.1",
+ "solana-address",
+ "solana-define-syscall 5.1.0",
+ "solana-program-error",
 ]
 
 [[package]]
 name = "solana-hash"
-version = "4.0.1"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5d48a6ee7b91fc7b998944ab026ed7b3e2fc8ee3bc58452644a86c2648152f"
+checksum = "6f4c847893a2ea50b4ae3ca723b124e07cd0544fecea3598f785168f9b78333f"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "five8",
  "serde",
  "serde_derive",
- "solana-atomic-u64",
- "solana-sanitize",
 ]
 
 [[package]]
 name = "solana-instruction"
-version = "3.1.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1b699a2c1518028a9982e255e0eca10c44d90006542d9d7f9f40dbce3f7c78"
+checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
 dependencies = [
- "borsh",
- "serde",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.1.0",
  "solana-instruction-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-instruction-error"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04259e03c05faf38a8c24217b5cfe4c90572ae6184ab49cddb1584fdd756d3f"
+checksum = "3b7d34343838343a3755b7dfb1e438d94c6db2263b519cfe3c2257af932b6e93"
 dependencies = [
  "num-traits",
  "solana-program-error",
@@ -636,12 +564,13 @@ dependencies = [
 
 [[package]]
 name = "solana-last-restart-slot"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcda154ec827f5fc1e4da0af3417951b7e9b8157540f81f936c4a8b1156134d0"
+checksum = "c22474b83d3c7c318e1c3a725784fc2d1d03b728e36369e58ce48769a61ed85e"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-get-sysvar",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -649,11 +578,11 @@ dependencies = [
 
 [[package]]
 name = "solana-msg"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "264275c556ea7e22b9d3f87d56305546a38d4eee8ec884f3b126236cb7dcbbb4"
+checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
 dependencies = [
- "solana-define-syscall 3.0.0",
+ "solana-define-syscall 5.1.0",
 ]
 
 [[package]]
@@ -665,14 +594,14 @@ dependencies = [
  "solana-account-info",
  "solana-define-syscall 4.0.1",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-program-error"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1af32c995a7b692a915bb7414d5f8e838450cf7c70414e763d8abcae7b51f28"
+checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
 dependencies = [
  "borsh",
 ]
@@ -688,30 +617,22 @@ dependencies = [
 
 [[package]]
 name = "solana-pubkey"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
-dependencies = [
- "solana-address 1.1.0",
-]
-
-[[package]]
-name = "solana-pubkey"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
 dependencies = [
- "solana-address 2.6.1",
+ "solana-address",
 ]
 
 [[package]]
 name = "solana-rent"
-version = "3.0.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b702d8c43711e3c8a9284a4f1bbc6a3de2553deb25b0c8142f9a44ef0ce5ddc1"
+checksum = "39f0d780bf8e8a1fe8b5b5fce1acad6b209485b86dec246e7523d5e4a8b7c7fc"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-get-sysvar",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -729,14 +650,14 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
 dependencies = [
- "solana-address 2.6.1",
+ "solana-address",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6430000e97083460b71d9fbadc52a2ab2f88f53b3a4c5e58c5ae3640a0e8c00"
+checksum = "8765316242300c48242d84a41614cb3388229ec353ba464f6fe62a733e41806f"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -745,57 +666,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-sha256-hasher"
+name = "solana-slot-hashes"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
-dependencies = [
- "sha2",
- "solana-define-syscall 4.0.1",
- "solana-hash 4.0.1",
-]
-
-[[package]]
-name = "solana-slot-hashes"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a293f952293281443c04f4d96afd9d547721923d596e92b4377ed2360f1746"
+checksum = "5c7ce2b4b8911bf2db3de7b6266e67bfc21a6a9f8c566fb096d9782ca2ad16ee"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 3.1.0",
+ "solana-get-sysvar",
+ "solana-hash",
  "solana-sdk-ids",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-slot-history"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f914f6b108f5bba14a280b458d023e3621c9973f27f015a4d755b50e88d89e97"
+checksum = "40427c04d3e808493cb5e3d1a97cef84d7c15cb6f89b15c5684d0d4027105600"
 dependencies = [
  "bv",
  "serde",
  "serde_derive",
+ "solana-get-sysvar",
  "solana-sdk-ids",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-stable-layout"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da74507795b6e8fb60b7c7306c0c36e2c315805d16eaaf479452661234685ac"
+checksum = "c9f6a291ba063a37780af29e7db14bdd3dc447584d8ba5b3fc4b88e2bbc982fa"
 dependencies = [
  "solana-instruction",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-stake-history"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c736a6aa0e53b9d264d90b06589fc0996f49f882f3e71842ed754fc57ffc1a43"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-clock",
+ "solana-get-sysvar",
+ "solana-sdk-ids",
+ "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-sysvar"
-version = "3.1.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3205cc7db64a0f1a20b7eb2405773fa64e45f7fe0fc7a73e50e90eca6b2b0be7"
+checksum = "ada7045bbfdd802af08fbc9c7e2b56ddabb20599d22e4c3840fcef5e7afb8324"
 dependencies = [
  "base64",
  "bincode",
@@ -804,22 +730,24 @@ dependencies = [
  "serde_derive",
  "solana-account-info",
  "solana-clock",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.1.0",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.0.1",
+ "solana-get-sysvar",
+ "solana-hash",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-memory",
- "solana-pubkey 4.2.0",
+ "solana-pubkey",
  "solana-rent",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-slot-hashes",
  "solana-slot-history",
+ "solana-stake-history",
  "solana-sysvar-id",
 ]
 
@@ -829,7 +757,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-address 2.6.1",
+ "solana-address",
  "solana-sdk-ids",
 ]
 
@@ -852,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -871,7 +799,7 @@ dependencies = [
  "solana-msg",
  "solana-program-entrypoint",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
 ]
 
 [[package]]
@@ -882,7 +810,7 @@ dependencies = [
  "solana-define-syscall 4.0.1",
  "solana-program-entrypoint",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
 ]
 
 [[package]]
@@ -893,7 +821,7 @@ dependencies = [
  "solana-epoch-stake",
  "solana-program-entrypoint",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
 ]
 
 [[package]]
@@ -913,14 +841,14 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -933,18 +861,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -954,30 +882,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "wincode"
@@ -1012,9 +928,9 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]

--- a/crates/litesvm/test_programs/Cargo.lock
+++ b/crates/litesvm/test_programs/Cargo.lock
@@ -312,9 +312,9 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.5.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -861,31 +861,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.25.13+spec-1.1.0"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
  "winnow",
 ]
 
@@ -928,9 +915,9 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "winnow"
-version = "1.0.4"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/crates/litesvm/test_programs/Cargo.toml
+++ b/crates/litesvm/test_programs/Cargo.toml
@@ -1,11 +1,12 @@
 [workspace]
-members = ["clock-example", "counter", "failure", "custom-syscall", "cpi-maker"]
+members = ["clock-example", "counter", "failure", "custom-syscall", "cpi-maker", "epoch-stake"]
 resolver = "2"
 
 [workspace.dependencies]
 borsh = "1.5.5"
 solana-account-info = "3.0"
 solana-clock = "3.0"
+solana-epoch-stake = "3.0"
 solana-cpi = "3.0"
 solana-define-syscall = "4.0"
 solana-instruction = "3.0"

--- a/crates/litesvm/test_programs/Cargo.toml
+++ b/crates/litesvm/test_programs/Cargo.toml
@@ -1,5 +1,12 @@
 [workspace]
-members = ["clock-example", "counter", "failure", "custom-syscall", "cpi-maker", "epoch-stake"]
+members = [
+    "clock-example",
+    "counter",
+    "failure",
+    "custom-syscall",
+    "cpi-maker",
+    "epoch-stake",
+]
 resolver = "2"
 
 [workspace.dependencies]
@@ -13,8 +20,8 @@ solana-instruction = "3.0"
 solana-msg = "3.0"
 solana-program-entrypoint = "3.0"
 solana-program-error = "3.0"
-solana-pubkey = "3.0"
-solana-sysvar = { version = "3.0", features = ["bincode"] }
+solana-pubkey = "4.2"
+solana-sysvar = { version = "4.1", features = ["bincode"] }
 
 
 [profile.release]

--- a/crates/litesvm/test_programs/epoch-stake/Cargo.toml
+++ b/crates/litesvm/test_programs/epoch-stake/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "test-program-epoch-stake"
+version = "0.0.0"
+edition = "2021"
+include = ["/src"]
+
+[features]
+custom-heap = []
+custom-panic = []
+
+[dependencies]
+solana-account-info = { workspace = true }
+solana-epoch-stake = { workspace = true }
+solana-program-entrypoint = { workspace = true }
+solana-program-error = { workspace = true }
+solana-pubkey = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]

--- a/crates/litesvm/test_programs/epoch-stake/src/lib.rs
+++ b/crates/litesvm/test_programs/epoch-stake/src/lib.rs
@@ -1,0 +1,32 @@
+//! Asserts `sol_get_epoch_stake` values configured on the LiteSVM host.
+//!
+//! Instruction data layout (48 bytes):
+//! - `vote_address`: 32 bytes
+//! - `expected_vote_stake`: u64 LE
+//! - `expected_total_stake`: u64 LE
+
+use {
+    solana_account_info::AccountInfo, solana_epoch_stake, solana_program_error::ProgramResult,
+    solana_pubkey::Pubkey,
+};
+
+solana_program_entrypoint::entrypoint!(process_instruction);
+
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    assert_eq!(instruction_data.len(), 48, "expected 48-byte ix data");
+
+    let vote_address = Pubkey::new_from_array(instruction_data[0..32].try_into().unwrap());
+    let expected_vote_stake = u64::from_le_bytes(instruction_data[32..40].try_into().unwrap());
+    let expected_total_stake = u64::from_le_bytes(instruction_data[40..48].try_into().unwrap());
+
+    let vote_stake = solana_epoch_stake::get_epoch_stake_for_vote_account(&vote_address);
+    let total_stake = solana_epoch_stake::get_epoch_total_stake();
+
+    assert_eq!(vote_stake, expected_vote_stake);
+    assert_eq!(total_stake, expected_total_stake);
+    Ok(())
+}

--- a/crates/litesvm/tests/epoch_stake.rs
+++ b/crates/litesvm/tests/epoch_stake.rs
@@ -1,0 +1,173 @@
+use {
+    litesvm::{error::LiteSVMError, LiteSVM},
+    solana_address::Address,
+    solana_keypair::Keypair,
+    solana_message::{Instruction, Message},
+    solana_signer::Signer,
+    solana_svm_callback::InvokeContextCallback,
+    solana_transaction::Transaction,
+    std::{collections::HashMap, path::PathBuf},
+};
+
+fn read_epoch_stake_program() -> Vec<u8> {
+    let mut so_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    so_path.push("test_programs/target/deploy/test_program_epoch_stake.so");
+    std::fs::read(&so_path).unwrap_or_else(|e| {
+        panic!(
+            "failed to read {}: {e}. Build with: cd crates/litesvm/test_programs && cargo build-sbf",
+            so_path.display()
+        )
+    })
+}
+
+#[test_log::test]
+fn epoch_stake_defaults_to_zero() {
+    let svm = LiteSVM::new();
+    let vote = Address::new_unique();
+
+    assert_eq!(svm.epoch_total_stake(), 0);
+    assert_eq!(svm.epoch_stake(&vote), 0);
+    assert_eq!(InvokeContextCallback::get_epoch_stake(&svm), 0);
+    assert_eq!(
+        InvokeContextCallback::get_epoch_stake_for_vote_account(&svm, &vote),
+        0
+    );
+}
+
+#[test_log::test]
+fn set_epoch_stake_updates_total() {
+    let mut svm = LiteSVM::new();
+    let vote_a = Address::new_unique();
+    let vote_b = Address::new_unique();
+
+    svm.set_epoch_stake(vote_a, 1_000).unwrap();
+    svm.set_epoch_stake(vote_b, 2_500).unwrap();
+    assert_eq!(svm.epoch_total_stake(), 3_500);
+    assert_eq!(InvokeContextCallback::get_epoch_stake(&svm), 3_500);
+    assert_eq!(
+        InvokeContextCallback::get_epoch_stake_for_vote_account(&svm, &vote_a),
+        1_000
+    );
+}
+
+#[test_log::test]
+fn overwriting_vote_stake_adjusts_total() {
+    let mut svm = LiteSVM::new();
+    let vote = Address::new_unique();
+
+    svm.set_epoch_stake(vote, 1_000).unwrap();
+    svm.set_epoch_stake(vote, 250).unwrap();
+
+    assert_eq!(svm.epoch_stake(&vote), 250);
+    assert_eq!(svm.epoch_total_stake(), 250);
+}
+
+#[test_log::test]
+fn setting_vote_stake_to_zero_removes_it_from_total() {
+    let mut svm = LiteSVM::new();
+    let vote_a = Address::new_unique();
+    let vote_b = Address::new_unique();
+
+    svm.set_epoch_stake(vote_a, 1_000).unwrap();
+    svm.set_epoch_stake(vote_b, 2_000).unwrap();
+    svm.set_epoch_stake(vote_a, 0).unwrap();
+
+    assert_eq!(svm.epoch_stake(&vote_a), 0);
+    assert_eq!(svm.epoch_stake(&vote_b), 2_000);
+    assert_eq!(svm.epoch_total_stake(), 2_000);
+}
+
+#[test_log::test]
+fn set_epoch_stake_rejects_overflow() {
+    let mut svm = LiteSVM::new();
+    let vote_a = Address::new_unique();
+    let vote_b = Address::new_unique();
+
+    svm.set_epoch_stake(vote_a, u64::MAX).unwrap();
+    let err = svm.set_epoch_stake(vote_b, 1).unwrap_err();
+    assert!(matches!(err, LiteSVMError::EpochStakeOverflow));
+    // Failed update must leave state unchanged.
+    assert_eq!(svm.epoch_stake(&vote_a), u64::MAX);
+    assert_eq!(svm.epoch_stake(&vote_b), 0);
+    assert_eq!(svm.epoch_total_stake(), u64::MAX);
+}
+
+#[test_log::test]
+fn set_epoch_stakes_sums_with_overflow_check() {
+    let mut svm = LiteSVM::new();
+    let vote = Address::new_unique();
+    svm.set_epoch_stake(Address::new_unique(), 99).unwrap();
+
+    let mut stakes = HashMap::new();
+    stakes.insert(vote, 7_000);
+    stakes.insert(Address::new_unique(), 3_000);
+    svm.set_epoch_stakes(stakes).unwrap();
+
+    assert_eq!(svm.epoch_total_stake(), 10_000);
+    assert_eq!(svm.epoch_stake(&vote), 7_000);
+
+    let mut overflowing = HashMap::new();
+    overflowing.insert(Address::new_unique(), u64::MAX);
+    overflowing.insert(Address::new_unique(), 1);
+    assert!(matches!(
+        svm.set_epoch_stakes(overflowing).unwrap_err(),
+        LiteSVMError::EpochStakeOverflow
+    ));
+    // Failed bulk replace must leave prior state unchanged.
+    assert_eq!(svm.epoch_total_stake(), 10_000);
+    assert_eq!(svm.epoch_stake(&vote), 7_000);
+}
+
+#[test_log::test]
+fn clone_preserves_epoch_stakes() {
+    let mut svm = LiteSVM::new();
+    let vote = Address::new_unique();
+    svm.set_epoch_stake(vote, 123).unwrap();
+    svm.set_epoch_stake(Address::new_unique(), 456).unwrap();
+
+    let cloned = svm.clone();
+    assert_eq!(cloned.epoch_stake(&vote), 123);
+    assert_eq!(cloned.epoch_total_stake(), 579);
+}
+
+#[test_log::test]
+fn sol_get_epoch_stake_syscall_reads_configured_values() {
+    let mut svm = LiteSVM::new();
+    let payer = Keypair::new();
+    let vote = Address::new_unique();
+    let vote_stake = 1_000_000_000u64;
+    // Total is derived: one other vote + this vote.
+    let other = Address::new_unique();
+    svm.set_epoch_stake(other, 9_000_000_000).unwrap();
+    svm.set_epoch_stake(vote, vote_stake).unwrap();
+    let total_stake = svm.epoch_total_stake();
+    assert_eq!(total_stake, 10_000_000_000);
+
+    let program_id = Address::new_unique();
+    svm.add_program(program_id, &read_epoch_stake_program())
+        .unwrap();
+    svm.airdrop(&payer.pubkey(), 1_000_000_000).unwrap();
+
+    let mut ix_data = Vec::with_capacity(48);
+    ix_data.extend_from_slice(vote.as_ref());
+    ix_data.extend_from_slice(&vote_stake.to_le_bytes());
+    ix_data.extend_from_slice(&total_stake.to_le_bytes());
+
+    let blockhash = svm.latest_blockhash();
+    let msg = Message::new_with_blockhash(
+        &[Instruction {
+            program_id,
+            accounts: vec![],
+            data: ix_data,
+        }],
+        Some(&payer.pubkey()),
+        &blockhash,
+    );
+    let tx = Transaction::new(&[&payer], msg, blockhash);
+    let res = svm.send_transaction(tx);
+    assert!(
+        res.is_ok(),
+        "sol_get_epoch_stake program failed: {:?}",
+        res.err()
+    );
+}


### PR DESCRIPTION
Presently, epoch_stake is always 0 and not settable by dev user

## Summary
- Add `LiteSVM::set_epoch_stake` / `set_epoch_stakes` to configure per-vote stakes for `sol_get_epoch_stake`
- Add `LiteSVM::epoch_stake` / `epoch_total_stake` to read them back