### PR TITLE
perf: don't clone the account store when writing the clock sysvar

### DIFF
--- a/crates/litesvm/Cargo.toml
+++ b/crates/litesvm/Cargo.toml
@@ -140,5 +140,9 @@ name = "max_perf"
 harness = false
 
 [[bench]]
+name = "set_clock"
+harness = false
+
+[[bench]]
 name = "hashing"
 harness = false

--- a/crates/litesvm/benches/set_clock.rs
+++ b/crates/litesvm/benches/set_clock.rs
@@ -1,0 +1,53 @@
+use {
+    criterion::{criterion_group, criterion_main, BenchmarkId, Criterion},
+    litesvm::LiteSVM,
+    solana_account::Account,
+    solana_address::Address,
+    solana_clock::Clock,
+};
+
+/// Builds an SVM pre-seeded with `num_accounts` dummy accounts on top of the
+/// accounts LiteSVM creates for itself.
+fn svm_with_accounts(num_accounts: usize) -> LiteSVM {
+    let mut svm = LiteSVM::new();
+    for i in 0..num_accounts {
+        let mut bytes = [0u8; 32];
+        bytes[..8].copy_from_slice(&(i as u64).to_le_bytes());
+        svm.set_account(
+            Address::new_from_array(bytes),
+            Account {
+                lamports: 1_000_000,
+                data: vec![0u8; 32],
+                owner: solana_sdk_ids::system_program::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    }
+    svm
+}
+
+/// Writing the clock sysvar should cost the same no matter how many accounts
+/// the SVM holds.
+fn bench_set_clock(c: &mut Criterion) {
+    let mut group = c.benchmark_group("set_clock");
+    for num_accounts in [1usize, 1_000, 10_000] {
+        let mut svm = svm_with_accounts(num_accounts);
+        let mut clock = svm.get_sysvar::<Clock>();
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_accounts),
+            &num_accounts,
+            |b, _| {
+                b.iter(|| {
+                    clock.slot += 1;
+                    svm.set_sysvar(&clock);
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_set_clock);
+criterion_main!(benches);

--- a/crates/litesvm/src/accounts_db.rs
+++ b/crates/litesvm/src/accounts_db.rs
@@ -159,11 +159,12 @@ impl AccountsDb {
                 let parsed = Clock::deserialize_from(account.data())
                     .map_err(|_| InvalidSysvarDataError::Clock)?;
                 self.programs_cache.set_slot_for_tests(parsed.slot);
-                let mut accounts_clone = self.inner.clone();
-                accounts_clone.insert(pubkey, account.clone());
+                let accounts = &self.inner;
                 cache.reset();
-                cache.fill_missing_entries(|pubkey, set_sysvar| {
-                    if let Some(acc) = accounts_clone.get(pubkey) {
+                cache.fill_missing_entries(|sysvar_pubkey, set_sysvar| {
+                    if *sysvar_pubkey == pubkey {
+                        set_sysvar(account.data())
+                    } else if let Some(acc) = accounts.get(sysvar_pubkey) {
                         set_sysvar(acc.data())
                     }
                 });

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -2225,4 +2225,43 @@ mod tests {
 
         assert!(!sanitized.message().is_writable(1));
     }
+
+    /// Writing the clock must refresh the whole sysvar cache — the new clock
+    /// included — without consulting a copy of the account store.
+    #[test]
+    fn setting_clock_refreshes_sysvar_cache() {
+        let mut svm = LiteSVM::new();
+        // An unrelated account, to make sure the cache is filled from the live
+        // store rather than a snapshot taken before it was added.
+        svm.set_account(
+            Address::new_unique(),
+            Account {
+                lamports: 1,
+                data: vec![],
+                owner: solana_sdk_ids::system_program::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+
+        let mut clock = svm.get_sysvar::<Clock>();
+        clock.slot = 1234;
+        clock.unix_timestamp = 5678;
+        svm.set_sysvar(&clock);
+
+        let cache = &svm.accounts.sysvar_cache;
+        let cached_clock = cache.get_clock().unwrap();
+        assert_eq!(cached_clock.slot, 1234);
+        assert_eq!(cached_clock.unix_timestamp, 5678);
+        assert_eq!(svm.get_sysvar::<Clock>().slot, 1234);
+
+        // The other sysvars must survive the cache reset.
+        assert!(cache.get_rent().is_ok());
+        assert!(cache.get_epoch_schedule().is_ok());
+        assert!(cache.get_epoch_rewards().is_ok());
+        assert!(cache.get_slot_hashes().is_ok());
+        assert!(cache.get_stake_history().is_ok());
+        assert!(cache.get_last_restart_slot().is_ok());
+    }
 }


### PR DESCRIPTION
The CLOCK_ID arm of `maybe_handle_sysvar_account` cloned the entire
`HashMap<Pubkey, AccountSharedData>` just so `fill_missing_entries` could
read the ~11 sysvar accounts out of a snapshot that already contained the
new clock. That made every clock write O(n) in the number of accounts, so
a run that advances the clock per transaction degrades as the store grows.

Use the same clone-free pattern the other sysvar arms already use via
`handle_sysvar`: borrow `&self.inner` and special-case the clock pubkey
inside the closure. Behaviour is identical — `add_account` inserts the new
clock into the store immediately afterwards.

set_clock benchmark (time per `set_sysvar::<Clock>()`):

    accounts   before      after
    1          3.96 us     1.04 us
    1,000      14.6 us     1.05 us
    10,000     124 us      1.09 us
    100,000    2.18 ms     1.07 us

The committed benchmark stops at 10,000 accounts to keep `cargo bench`
fast; the 100,000 row above was measured with the same bench locally.

