### PR TITLE
fix(node): ship register-tracing by default so SBF_TRACE_DIR works on npm

### DIFF
--- a/crates/node-litesvm/CHANGELOG.md
+++ b/crates/node-litesvm/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Bump to Agave 4.1 [(#373)](https://github.com/LiteSVM/litesvm/pull/373).
 - Use `wincode` for sysvar serialization in the native bindings [(#376)](https://github.com/LiteSVM/litesvm/pull/376).
 
+### Fixed
+
+- Build the published binaries with the `register-tracing` feature enabled by default, so setting `SBF_TRACE_DIR` now produces SBPF register traces instead of being silently ignored. Previously this only worked for Rust consumers who opted into the feature, leaving tools such as `sbpf-coverage` reporting 0% coverage for anyone driving LiteSVM from JavaScript [(#XXX)](https://github.com/LiteSVM/litesvm/pull/XXX).
+
 ## [1.2.1] - 2026-07-01
 
 ### Fixed

--- a/crates/node-litesvm/CHANGELOG.md
+++ b/crates/node-litesvm/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Fixed
 
-- Build the published binaries with the `register-tracing` feature enabled by default, so setting `SBF_TRACE_DIR` now produces SBPF register traces instead of being silently ignored. Previously this only worked for Rust consumers who opted into the feature, leaving tools such as `sbpf-coverage` reporting 0% coverage for anyone driving LiteSVM from JavaScript [(#XXX)](https://github.com/LiteSVM/litesvm/pull/XXX).
+- Build the published binaries with the `register-tracing` feature enabled by default, so setting `SBF_TRACE_DIR` now produces SBPF register traces instead of being silently ignored. Previously this only worked for Rust consumers who opted into the feature, leaving tools such as `sbpf-coverage` reporting 0% coverage for anyone driving LiteSVM from JavaScript [(#397)](https://github.com/LiteSVM/litesvm/pull/397).
 
 ## [1.2.1] - 2026-07-01
 

--- a/crates/node-litesvm/Cargo.toml
+++ b/crates/node-litesvm/Cargo.toml
@@ -7,9 +7,6 @@ repository = "https://github.com/LiteSVM/litesvm"
 license = "MIT"
 
 [features]
-# `register-tracing` ships by default so that `SBF_TRACE_DIR` works out of the
-# box with the prebuilt binaries published to npm. Without it the env var is
-# silently ignored, which produces empty coverage reports rather than an error.
 default = ["register-tracing"]
 sbpf-debugger = ["litesvm/sbpf-debugger"]
 register-tracing = ["litesvm/register-tracing"]

--- a/crates/node-litesvm/Cargo.toml
+++ b/crates/node-litesvm/Cargo.toml
@@ -7,7 +7,10 @@ repository = "https://github.com/LiteSVM/litesvm"
 license = "MIT"
 
 [features]
-default = []
+# `register-tracing` ships by default so that `SBF_TRACE_DIR` works out of the
+# box with the prebuilt binaries published to npm. Without it the env var is
+# silently ignored, which produces empty coverage reports rather than an error.
+default = ["register-tracing"]
 sbpf-debugger = ["litesvm/sbpf-debugger"]
 register-tracing = ["litesvm/register-tracing"]
 


### PR DESCRIPTION
### Summary

Enable `register-tracing` by default in `node-litesvm` so `SBF_TRACE_DIR` works out of the box with the prebuilt npm binaries.

Currently, the published binaries are built without the feature, causing `SBF_TRACE_DIR` to be silently ignored and preventing JS/TS users from generating register traces for tools like `sbpf-coverage` unless they rebuild from source.

### Change

```diff
[features]
-default = []
+default = ["register-tracing"]
```
