### PR TITLE
fix(node): accept plain slot hash inputs

### DIFF
--- a/crates/node-litesvm/CHANGELOG.md
+++ b/crates/node-litesvm/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Allow `setSlotHashes` to accept plain JavaScript objects [(#178)](https://github.com/LiteSVM/litesvm/issues/178).
 - Build the published binaries with the `register-tracing` feature enabled by default, so setting `SBF_TRACE_DIR` now produces SBPF register traces instead of being silently ignored. Previously this only worked for Rust consumers who opted into the feature, leaving tools such as `sbpf-coverage` reporting 0% coverage for anyone driving LiteSVM from JavaScript [(#397)](https://github.com/LiteSVM/litesvm/pull/397).
 
 ## [1.2.1] - 2026-07-01

--- a/crates/node-litesvm/litesvm/internal.d.ts
+++ b/crates/node-litesvm/litesvm/internal.d.ts
@@ -346,7 +346,7 @@ export declare class LiteSvm {
   getLastRestartSlot(): bigint
   setLastRestartSlot(slot: bigint): void
   getSlotHashes(): Array<SlotHash>
-  setSlotHashes(hashes: Array<SlotHash>): void
+  setSlotHashes(hashes: Array<SlotHashInput>): void
   getSlotHistory(): SlotHistory
   setSlotHistory(history: SlotHistory): void
   getStakeHistory(): StakeHistory
@@ -588,6 +588,11 @@ export declare const enum InstructionErrorFieldless {
   MaxInstructionTraceLengthExceeded = 50,
   BuiltinProgramsMustConsumeComputeUnits = 51,
   BorshIoError = 52
+}
+
+export interface SlotHashInput {
+  slot: bigint
+  hash: string
 }
 
 export declare const enum SlotHistoryCheck {

--- a/crates/node-litesvm/src/lib.rs
+++ b/crates/node-litesvm/src/lib.rs
@@ -6,8 +6,13 @@ use {
         compute_budget::ComputeBudget,
         feature_set::FeatureSet,
         sysvar::{
-            clock::Clock, epoch_rewards::EpochRewards, epoch_schedule::EpochSchedule, rent::Rent,
-            slot_hashes::SlotHash, slot_history::SlotHistory, stake_history::StakeHistory,
+            clock::Clock,
+            epoch_rewards::EpochRewards,
+            epoch_schedule::EpochSchedule,
+            rent::Rent,
+            slot_hashes::{SlotHash, SlotHashInput},
+            slot_history::SlotHistory,
+            stake_history::StakeHistory,
         },
         transaction_metadata::{
             AddressAndAccount, FailedTransactionMetadata, SimulatedTransactionInfo,
@@ -400,7 +405,7 @@ impl LiteSvm {
     }
 
     #[napi]
-    pub fn set_slot_hashes(&mut self, hashes: Vec<&SlotHash>) -> Result<()> {
+    pub fn set_slot_hashes(&mut self, hashes: Vec<SlotHashInput>) -> Result<()> {
         let mut intermediate: Vec<(u64, solana_hash::Hash)> = Vec::with_capacity(hashes.len());
         for h in hashes {
             let converted_hash = try_parse_hash(&h.hash)?;

--- a/crates/node-litesvm/src/sysvar/slot_hashes.rs
+++ b/crates/node-litesvm/src/sysvar/slot_hashes.rs
@@ -29,3 +29,10 @@ impl SlotHash {
         self.hash = hash;
     }
 }
+
+#[derive(Debug, Clone)]
+#[napi(object)]
+pub struct SlotHashInput {
+    pub slot: BigInt,
+    pub hash: String,
+}

--- a/crates/node-litesvm/tests/sysvar.test.ts
+++ b/crates/node-litesvm/tests/sysvar.test.ts
@@ -1,4 +1,4 @@
-import { Clock, LiteSVM, Rent } from "litesvm";
+import { Clock, LiteSVM, Rent, SlotHash } from "litesvm";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
@@ -21,4 +21,21 @@ test("sysvar", () => {
 	svm.setClock(newClock);
 	const clockAfter = svm.getClock();
 	assert.strictEqual(clockAfter.epoch, newClock.epoch);
+});
+
+test("setSlotHashes accepts object literals", () => {
+	const svm = new LiteSVM();
+	const slotHashes = [
+		{
+			slot: 1000n,
+			hash: "G4caYtkdHZW5aPWokD6r1E3pnAxJmvXBsw3JtQFkMY8z",
+		},
+	];
+
+	svm.setSlotHashes(slotHashes);
+
+	const [slotHash] = svm.getSlotHashes();
+	assert(slotHash instanceof SlotHash);
+	assert.strictEqual(slotHash.slot, slotHashes[0].slot);
+	assert.strictEqual(slotHash.hash, slotHashes[0].hash);
 });


### PR DESCRIPTION
## Summary

Fixes #178.

TypeScript accepts a structural `{ slot, hash }` value for `setSlotHashes`, but the native method previously required references to the NAPI `SlotHash` class. At runtime, a plain object therefore failed with `Failed to recover SlotHash type from napi value`.

Add a setter-only `SlotHashInput` NAPI object and accept that input in the native setter. The existing `SlotHash` NAPI class is deliberately preserved for getter results and runtime compatibility.

## Compatibility

- `SlotHash` remains an exported runtime class.
- `getSlotHashes()` continues to return `SlotHash` instances.
- Existing `SlotHash` instances remain structurally valid setter inputs.
- Plain `{ slot, hash }` object literals now work as the public TypeScript signature implies.

## Regression test

The new test passes an object literal to `setSlotHashes`, checks the values returned by `getSlotHashes`, and asserts that the returned value is still `instanceof SlotHash`.

## Validation

- Full Node test suite — 23 passed
- `yarn build:js`
- `yarn lint:js`
- `cargo test -p litesvm-node`
- `cargo clippy -p litesvm-node --all-targets`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
