### PR TITLE
fix: align rent epoch when loading transaction accounts

### DIFF
--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -1344,10 +1344,16 @@ impl LiteSVM {
                             })
                             .unwrap_or_else(|| {
                                 let mut default_account = AccountSharedData::default();
-                                default_account.set_rent_epoch(0);
+                                default_account.set_rent_epoch(u64::MAX);
                                 (default_account.data().len(), default_account)
                             })
                     };
+                    if message.is_writable(i)
+                        && account.rent_epoch() != u64::MAX
+                        && rent.is_exempt(account.lamports(), account.data().len())
+                    {
+                        account.set_rent_epoch(u64::MAX);
+                    }
                     if !validated_fee_payer && (!message.is_invoked(i) || is_instruction_account) {
                         validate_fee_payer(key, &mut account, i as IndexOfAccount, &rent, fee)?;
                         validated_fee_payer = true;

--- a/crates/litesvm/tests/system.rs
+++ b/crates/litesvm/tests/system.rs
@@ -1,5 +1,6 @@
 use {
     litesvm::LiteSVM,
+    solana_account::Account,
     solana_address::Address,
     solana_instruction::error::InstructionError,
     solana_keypair::Keypair,
@@ -47,7 +48,7 @@ fn system_transfer() {
 }
 
 #[test_log::test]
-fn system_create_account() {
+fn rent_epoch_created_account_matches_svm() {
     let from_keypair = Keypair::new();
     let new_account = Keypair::new();
     let from = from_keypair.pubkey();
@@ -78,6 +79,37 @@ fn system_create_account() {
     assert_eq!(account.lamports, rent_amount);
     assert_eq!(account.data.len(), space);
     assert_eq!(account.owner, solana_sdk_ids::system_program::id());
+    assert_eq!(account.rent_epoch, u64::MAX);
+}
+
+#[test_log::test]
+fn rent_epoch_existing_writable_rent_exempt_account_matches_svm() {
+    let payer = Keypair::new();
+    let recipient = Address::new_unique();
+    let mut svm = LiteSVM::new();
+    svm.airdrop(&payer.pubkey(), LAMPORTS_PER_SOL).unwrap();
+    svm.set_account(
+        recipient,
+        Account {
+            lamports: svm.minimum_balance_for_rent_exemption(0),
+            owner: solana_sdk_ids::system_program::id(),
+            rent_epoch: 7,
+            ..Account::default()
+        },
+    )
+    .unwrap();
+
+    let tx = Transaction::new(
+        &[&payer],
+        Message::new(
+            &[transfer(&payer.pubkey(), &recipient, 1)],
+            Some(&payer.pubkey()),
+        ),
+        svm.latest_blockhash(),
+    );
+    svm.send_transaction(tx).unwrap();
+
+    assert_eq!(svm.get_account(&recipient).unwrap().rent_epoch, u64::MAX);
 }
 
 #[test_log::test]


### PR DESCRIPTION
## Summary

LiteSVM manual transaction-account loading diverged from Solana SVM rent semantics in two places: an absent account started with rent_epoch = 0, and an existing writable rent-exempt account kept a stale epoch. Solana SVM uses the u64::MAX sentinel for both cases.

This patch initializes absent transaction accounts with u64::MAX and normalizes an existing writable account only when the active Rent sysvar says it is exempt. It matches the Agave v4.2.0 account loader behavior: https://github.com/anza-xyz/agave/blob/v4.2.0/svm/src/account_loader.rs#L604-L633

## Tests

- cargo test -p litesvm rent_epoch_
- cargo +nightly fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --features precompiles with only locally unavailable generated-SBF-fixture tests skipped

The two focused regressions pass after rebasing onto current master. GitHub CI builds the SBF fixtures before running the complete unfiltered suite.

## Scope

No historical replay behavior, compute metering, public API, dependencies, or lockfile changes are included.