### PR TITLE
Allow sending and simulating v1 transactions from the node bindings

### DIFF
--- a/crates/node-litesvm/CHANGELOG.md
+++ b/crates/node-litesvm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Route version 1 transactions through the native bindings in `sendTransaction` and `simulateTransaction`. The runtime gained V1 transaction support in v1.4.0, but the JavaScript wrapper still rejected them with `Unsupported transaction version: 1`.
+
 ## [1.4.0] - 2026-08-24
 
 ### Changed

--- a/crates/node-litesvm/litesvm/index.ts
+++ b/crates/node-litesvm/litesvm/index.ts
@@ -425,6 +425,7 @@ export class LiteSVM {
 			case "legacy":
 				return internal.sendLegacyTransaction(serialized);
 			case 0:
+			case 1:
 				return internal.sendVersionedTransaction(serialized);
 			default:
 				throw new Error(`Unsupported transaction version: ${version}`);
@@ -453,6 +454,7 @@ export class LiteSVM {
 				case "legacy":
 					return internal.simulateLegacyTransaction(serialized);
 				case 0:
+				case 1:
 					return internal.simulateVersionedTransaction(serialized);
 				default:
 					throw new Error(`Unsupported transaction version: ${version}`);

--- a/crates/node-litesvm/tests/v1Tx.test.ts
+++ b/crates/node-litesvm/tests/v1Tx.test.ts
@@ -1,0 +1,104 @@
+import { getTransferSolInstruction } from "@solana-program/system";
+import {
+	appendTransactionMessageInstruction,
+	createTransactionMessage,
+	generateKeyPairSigner,
+	Instruction,
+	lamports,
+	pipe,
+	setTransactionMessageComputeUnitLimit,
+	setTransactionMessageFeePayerSigner,
+	setTransactionMessageLoadedAccountsDataSizeLimit,
+	signTransactionMessageWithSigners,
+	TransactionSigner,
+} from "@solana/kit";
+import { LiteSVM, SimulatedTransactionInfo, TransactionMetadata } from "litesvm";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { generateAddress, LAMPORTS_PER_SOL } from "./util";
+
+const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
+const MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES = 64 * 1024 * 1024;
+
+// Unset resource limits in a version 1 transaction config are treated as
+// zero, so the transaction sets generous values explicitly.
+async function getSignedV1Transaction(
+	svm: LiteSVM,
+	payer: TransactionSigner,
+	instruction: Instruction,
+) {
+	return await pipe(
+		createTransactionMessage({ version: 1 }),
+		(tx) => setTransactionMessageComputeUnitLimit(MAX_COMPUTE_UNIT_LIMIT, tx),
+		(tx) =>
+			setTransactionMessageLoadedAccountsDataSizeLimit(
+				MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+				tx,
+			),
+		(tx) => setTransactionMessageFeePayerSigner(payer, tx),
+		(tx) => appendTransactionMessageInstruction(instruction, tx),
+		(tx) => svm.setTransactionMessageLifetimeUsingLatestBlockhash(tx),
+		(tx) => signTransactionMessageWithSigners(tx),
+	);
+}
+
+test("send a version 1 transaction", async () => {
+	// Given the following addresses and signers.
+	const [payer, receiver] = await Promise.all([
+		generateKeyPairSigner(),
+		generateAddress(),
+	]);
+
+	// And a LiteSVM client such that the payer has some balance.
+	const svm = new LiteSVM();
+	svm.airdrop(payer.address, lamports(LAMPORTS_PER_SOL));
+
+	// When we send a transfer instruction using a version 1 transaction.
+	const transferredAmount = lamports(1_000_000n);
+	const transaction = await getSignedV1Transaction(
+		svm,
+		payer,
+		getTransferSolInstruction({
+			source: payer,
+			destination: receiver,
+			amount: transferredAmount,
+		}),
+	);
+	const result = svm.sendTransaction(transaction);
+
+	// Then the transaction succeeds and the receiver has received the
+	// transferred amount.
+	assert.ok(result instanceof TransactionMetadata);
+	const balanceAfter = svm.getBalance(receiver);
+	assert.strictEqual(balanceAfter, transferredAmount);
+});
+
+test("simulate a version 1 transaction", async () => {
+	// Given the following addresses and signers.
+	const [payer, receiver] = await Promise.all([
+		generateKeyPairSigner(),
+		generateAddress(),
+	]);
+
+	// And a LiteSVM client such that the payer has some balance.
+	const svm = new LiteSVM();
+	svm.airdrop(payer.address, lamports(LAMPORTS_PER_SOL));
+
+	// When we simulate a transfer instruction using a version 1 transaction.
+	const transferredAmount = lamports(1_000_000n);
+	const transaction = await getSignedV1Transaction(
+		svm,
+		payer,
+		getTransferSolInstruction({
+			source: payer,
+			destination: receiver,
+			amount: transferredAmount,
+		}),
+	);
+	const result = svm.simulateTransaction(transaction);
+
+	// Then the simulation succeeds and no lamports have actually moved.
+	assert.ok(result instanceof SimulatedTransactionInfo);
+	const balanceAfter = svm.getBalance(receiver);
+	assert.strictEqual(balanceAfter, null);
+});


### PR DESCRIPTION
This PR routes version 1 transactions through the existing native bindings in the node wrapper. #399 added v1 transaction support to the runtime, but `sendTransaction` and `simulateTransaction` still switch on `legacy | 0` and throw `Unsupported transaction version: 1` for anything else. Since `VersionedTransaction` already deserialises v1 payloads on the Rust side, the fix is simply to route version `1` through the existing `sendVersionedTransaction` and `simulateVersionedTransaction` bindings.

I've added a test that sends and simulates a v1 transfer end to end. One thing worth calling out: unset resource limits in a v1 transaction config are treated as zero (same as the Rust tests' `permissive_config()`), so a bare v1 transaction fails with `MaxLoadedAccountsDataSizeExceeded`. The test therefore sets generous compute unit and loaded accounts data size limits explicitly, and I've left a comment explaining why.

For context, I ran into this whilst bumping `litesvm` to 1.4.0 in [kit-plugins](https://github.com/anza-xyz/kit-plugins), where v1 transaction planning now works but execution was blocked by this wrapper.
