### PR TITLE
feat: per-instruction inspect hooks on InvocationInspectCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `InvocationInspectCallback::before_instruction` / `after_instruction`: per-top-level-instruction hooks (default no-op) that expose the `InvokeContext`, and therefore every account's state, between instructions of a transaction.
+
 ## [0.16.0] - 2026-08-24
 
 ### Added

--- a/crates/litesvm/src/lib.rs
+++ b/crates/litesvm/src/lib.rs
@@ -287,7 +287,7 @@ Other things you can do with `litesvm` include:
 | Feature | Description |
 |---|---|
 | `precompiles` | Loads the standard precompiles (ed25519, secp256k1) alongside the builtins. Enables [`with_precompiles`](LiteSVM::with_precompiles). |
-| `invocation-inspect-callback` | Enables the [`InvocationInspectCallback`] trait and [`set_invocation_inspect_callback`](LiteSVM::set_invocation_inspect_callback), giving low-level access to the `InvokeContext` before and after each transaction. |
+| `invocation-inspect-callback` | Enables the [`InvocationInspectCallback`] trait and [`set_invocation_inspect_callback`](LiteSVM::set_invocation_inspect_callback), giving low-level access to the `InvokeContext` before and after each transaction, and before and after each top-level instruction. |
 | `register-tracing` | Enables BPF register-level tracing. Implies `invocation-inspect-callback`. See [`LiteSVM::new_debuggable`] and [`register_tracing::DefaultRegisterTracingCallback`]. |
 | `hashbrown` | Switches internal hash maps to `hashbrown`. |
 | `serde` | Enables serde serialization/deserialization on internal types. |
@@ -317,6 +317,7 @@ use indexmap::IndexMap;
 use precompiles::load_precompiles;
 #[cfg(feature = "nodejs-internal")]
 use qualifier_attr::qualifiers;
+use solana_instruction_error::InstructionError;
 #[allow(deprecated)]
 use solana_sysvar::recent_blockhashes::IterItem;
 #[allow(deprecated)]
@@ -1492,12 +1493,33 @@ impl LiteSVM {
                     self.enable_register_tracing,
                 );
 
+                #[cfg(feature = "invocation-inspect-callback")]
+                let inspect = Arc::clone(&self.invocation_inspect_callback);
+                #[cfg(feature = "invocation-inspect-callback")]
+                let mut before_instruction = |index: usize, ctx: &mut InvokeContext| {
+                    inspect.before_instruction(self, tx, index, ctx);
+                };
+                #[cfg(feature = "invocation-inspect-callback")]
+                let mut after_instruction = |index: usize,
+                                             ctx: &InvokeContext,
+                                             result: &Result<(), InstructionError>,
+                                             cu: u64| {
+                    inspect.after_instruction(self, tx, index, ctx, result, cu);
+                };
+                #[cfg(not(feature = "invocation-inspect-callback"))]
+                let mut before_instruction = |_: usize, _: &mut InvokeContext| {};
+                #[cfg(not(feature = "invocation-inspect-callback"))]
+                let mut after_instruction =
+                    |_: usize, _: &InvokeContext, _: &Result<(), InstructionError>, _: u64| {};
+
                 let mut tx_result = process_message(
                     message,
                     &program_indices,
                     &mut invoke_context,
                     &mut ExecuteTimings::default(),
                     &mut accumulated_consume_units,
+                    &mut before_instruction,
+                    &mut after_instruction,
                 )
                 .map(|_| ());
 
@@ -2249,6 +2271,38 @@ pub trait InvocationInspectCallback: Send + Sync {
         invoke_context: &InvokeContext,
         enable_register_tracing: bool,
     );
+
+    /// Called right before top-level instruction `instruction_index` executes.
+    ///
+    /// Default: no-op, so existing callbacks keep compiling.
+    fn before_instruction(
+        &self,
+        _svm: &LiteSVM,
+        _tx: &SanitizedTransaction,
+        _instruction_index: usize,
+        _invoke_context: &mut InvokeContext,
+    ) {
+    }
+
+    /// Called right after top-level instruction `instruction_index` executes,
+    /// with its result and the compute units it consumed.
+    ///
+    /// The transaction's accounts are still loaded in
+    /// `invoke_context.transaction_context`, so this is the place to observe
+    /// state *between* instructions: what every account looked like after
+    /// instruction 2 and before instruction 3, without replaying prefixes.
+    ///
+    /// Default: no-op.
+    fn after_instruction(
+        &self,
+        _svm: &LiteSVM,
+        _tx: &SanitizedTransaction,
+        _instruction_index: usize,
+        _invoke_context: &InvokeContext,
+        _result: &Result<(), InstructionError>,
+        _compute_units_consumed: u64,
+    ) {
+    }
 }
 
 #[cfg(feature = "invocation-inspect-callback")]

--- a/crates/litesvm/src/message_processor.rs
+++ b/crates/litesvm/src/message_processor.rs
@@ -1,10 +1,21 @@
 // copied from agave commit 63b13a1f6ad263fb62e1f80156eaf09838f1aff0
 // with some execute_timings usage removed
 use {
+    solana_instruction_error::InstructionError,
     solana_program_runtime::invoke_context::InvokeContext, solana_svm_timings::ExecuteTimings,
     solana_svm_transaction::svm_message::SVMMessage, solana_transaction_context::IndexOfAccount,
     solana_transaction_error::TransactionError,
 };
+
+/// Called right before a top-level instruction executes.
+pub(crate) type BeforeInstructionHook<'h> = dyn FnMut(usize, &mut InvokeContext) + 'h;
+
+/// Called right after a top-level instruction executes, with its result and
+/// the compute units it consumed. The `InvokeContext` still holds the
+/// transaction's account state at this point, so the hook can observe every
+/// account exactly as it stands between instructions.
+pub(crate) type AfterInstructionHook<'h> =
+    dyn FnMut(usize, &InvokeContext, &Result<(), InstructionError>, u64) + 'h;
 
 /// Process a message.
 /// This method calls each instruction in the message over the set of loaded accounts.
@@ -17,6 +28,8 @@ pub(crate) fn process_message<'ix_data>(
     invoke_context: &mut InvokeContext<'_, 'ix_data>,
     execute_timings: &mut ExecuteTimings,
     accumulated_consumed_units: &mut u64,
+    before_instruction: &mut BeforeInstructionHook<'_>,
+    after_instruction: &mut AfterInstructionHook<'_>,
 ) -> Result<(), TransactionError> {
     debug_assert_eq!(program_indices.len(), message.num_instructions());
     invoke_context
@@ -32,6 +45,7 @@ pub(crate) fn process_message<'ix_data>(
             .enumerate()
     {
         let mut compute_units_consumed = 0;
+        before_instruction(top_level_instruction_index, invoke_context);
         let result = if invoke_context.is_precompile(program_id) {
             invoke_context.process_precompile(
                 program_id,
@@ -41,6 +55,12 @@ pub(crate) fn process_message<'ix_data>(
         } else {
             invoke_context.process_instruction(&mut compute_units_consumed, execute_timings)
         };
+        after_instruction(
+            top_level_instruction_index,
+            invoke_context,
+            &result,
+            compute_units_consumed,
+        );
 
         *accumulated_consumed_units =
             accumulated_consumed_units.saturating_add(compute_units_consumed);

--- a/crates/litesvm/tests/instruction_hook.rs
+++ b/crates/litesvm/tests/instruction_hook.rs
@@ -1,0 +1,147 @@
+#![cfg(feature = "invocation-inspect-callback")]
+
+use {
+    litesvm::{InvocationInspectCallback, LiteSVM},
+    solana_account::ReadableAccount,
+    solana_address::Address,
+    solana_instruction_error::InstructionError,
+    solana_keypair::Keypair,
+    solana_message::Message,
+    solana_program_runtime::invoke_context::InvokeContext,
+    solana_signer::Signer,
+    solana_system_interface::instruction::transfer,
+    solana_transaction::{sanitized::SanitizedTransaction, Transaction},
+    solana_transaction_context::IndexOfAccount,
+    std::sync::{Arc, Mutex},
+};
+
+/// `(instruction index, fee payer lamports after it, succeeded, compute units)`.
+type Observation = (usize, u64, bool, u64);
+
+/// Records the fee payer's lamports after every top-level instruction.
+struct BalanceAfterEachInstruction {
+    seen: Arc<Mutex<Vec<Observation>>>,
+}
+
+impl InvocationInspectCallback for BalanceAfterEachInstruction {
+    fn before_invocation(
+        &self,
+        _: &LiteSVM,
+        _: &SanitizedTransaction,
+        _: &[IndexOfAccount],
+        _: &mut InvokeContext,
+        _: bool,
+    ) {
+    }
+
+    fn after_invocation(
+        &self,
+        _: &LiteSVM,
+        _: &SanitizedTransaction,
+        _: &[IndexOfAccount],
+        _: &InvokeContext,
+        _: bool,
+    ) {
+    }
+
+    fn after_instruction(
+        &self,
+        _: &LiteSVM,
+        _: &SanitizedTransaction,
+        instruction_index: usize,
+        invoke_context: &InvokeContext,
+        result: &Result<(), InstructionError>,
+        compute_units_consumed: u64,
+    ) {
+        // Account 0 is the fee payer in this test's message.
+        let lamports = invoke_context
+            .transaction_context
+            .accounts()
+            .try_borrow(0)
+            .unwrap()
+            .lamports();
+        self.seen.lock().unwrap().push((
+            instruction_index,
+            lamports,
+            result.is_ok(),
+            compute_units_consumed,
+        ));
+    }
+}
+
+#[test]
+fn after_instruction_sees_state_between_instructions() {
+    let mut svm = LiteSVM::new();
+    let payer = Keypair::new();
+    let a = Address::new_unique();
+    let b = Address::new_unique();
+    let start = 1_000_000_000u64;
+    svm.airdrop(&payer.pubkey(), start).unwrap();
+
+    // Install the hook after the airdrop, which is itself a transaction.
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    svm.set_invocation_inspect_callback(BalanceAfterEachInstruction {
+        seen: Arc::clone(&seen),
+    });
+
+    // Two transfers in one transaction. The hook must see the balance after
+    // the first one and before the second one, which no post-transaction
+    // view can show.
+    let (first, second) = (100_000_000u64, 250_000_000u64);
+    let msg = Message::new(
+        &[
+            transfer(&payer.pubkey(), &a, first),
+            transfer(&payer.pubkey(), &b, second),
+        ],
+        Some(&payer.pubkey()),
+    );
+    let tx = Transaction::new(&[&payer], msg, svm.latest_blockhash());
+    let meta = svm.send_transaction(tx).unwrap();
+
+    let seen = seen.lock().unwrap();
+    assert_eq!(seen.len(), 2, "one observation per top-level instruction");
+    let fee = meta.fee;
+    let (i0, after_first, ok0, _) = seen[0];
+    let (i1, after_second, ok1, _) = seen[1];
+    assert_eq!((i0, i1), (0, 1));
+    assert!(ok0 && ok1);
+    assert_eq!(after_first, start - fee - first);
+    assert_eq!(after_second, start - fee - first - second);
+    assert_eq!(svm.get_balance(&payer.pubkey()).unwrap(), after_second);
+}
+
+#[test]
+fn after_instruction_reports_the_failing_instruction() {
+    let mut svm = LiteSVM::new();
+    let payer = Keypair::new();
+    let a = Address::new_unique();
+    svm.airdrop(&payer.pubkey(), 10_000_000).unwrap();
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    svm.set_invocation_inspect_callback(BalanceAfterEachInstruction {
+        seen: Arc::clone(&seen),
+    });
+
+    // Second transfer exceeds the balance: instruction 1 fails, 0 succeeded.
+    let msg = Message::new(
+        &[
+            transfer(&payer.pubkey(), &a, 1_000_000),
+            transfer(&payer.pubkey(), &a, 1_000_000_000),
+        ],
+        Some(&payer.pubkey()),
+    );
+    let tx = Transaction::new(&[&payer], msg, svm.latest_blockhash());
+    let failed = svm.send_transaction(tx).unwrap_err();
+
+    let seen = seen.lock().unwrap();
+    assert_eq!(seen.len(), 2);
+    assert!(seen[0].2, "first instruction succeeded");
+    assert!(!seen[1].2, "second instruction failed");
+    // The hook saw the first transfer applied mid-transaction…
+    assert_eq!(seen[0].1, 10_000_000 - failed.meta.fee - 1_000_000);
+    // …but the failed transaction commits nothing except the fee.
+    assert_eq!(
+        svm.get_balance(&payer.pubkey()).unwrap(),
+        10_000_000 - failed.meta.fee
+    );
+}


### PR DESCRIPTION
## What

Adds two methods to `InvocationInspectCallback`, both default no-ops:

```rust
fn before_instruction(&self, svm, tx, instruction_index, invoke_context: &mut InvokeContext) {}
fn after_instruction(&self, svm, tx, instruction_index, invoke_context: &InvokeContext,
                     result: &Result<(), InstructionError>, compute_units_consumed: u64) {}
```

They're called from `process_message` around every top-level instruction. `after_instruction` runs while the transaction's accounts are still loaded in `invoke_context.transaction_context`, so a callback can read every account exactly as it stands *between* instructions.

## Why

Today the callback sees the `InvokeContext` before and after the whole transaction. To know what an account looked like after instruction 2 and before instruction 3 you have to replay the message as prefixes (`0..=k` for each `k`), which is n executions instead of one and breaks for anything that depends on the full message (compute budget limits, precompiles reading all instruction data).

I hit this building a step-through view for svmscope (a mainnet transaction replayer on LiteSVM): per-instruction state, compute and result are exactly what a debugger, a CU profiler, or a "which instruction changed this account" tool needs, and they're all one hook away from the existing callback.

## Design notes

- Default implementations, so every existing `InvocationInspectCallback` compiles unchanged.
- The hooks are threaded into `process_message` as two closures; with the feature off they're empty closures, so the non-feature build has no behaviour change.
- The instruction's `Result` and consumed CU are passed to `after_instruction`; on failure the callback still sees the state at the point of failure, before the transaction is rolled back.
- Only top-level instructions for now. CPI-level hooks would need `InvokeContext` support upstream; this PR keeps the change inside LiteSVM's vendored message loop.

## Tests

`tests/instruction_hook.rs` (feature-gated):
- a two-transfer transaction: the hook observes the payer's balance after each transfer, and the values match `start − fee − first` and `start − fee − first − second`;
- a transaction whose second transfer overdraws: the hook reports instruction 0 succeeded and 1 failed, saw the first transfer applied mid-transaction, and the committed state is only the fee.

`cargo test -p litesvm --features invocation-inspect-callback` and `cargo clippy --all-targets --features invocation-inspect-callback -- -D warnings` are clean on my machine (the two `counter_test` cases need the SBF test programs built and fail the same way on master here).
