### PR TITLE
feat: expose state snapshots in the node bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,6 +2001,7 @@ dependencies = [
  "agave-feature-set",
  "bv",
  "litesvm",
+ "litesvm-persistence",
  "napi",
  "napi-build",
  "napi-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ indexmap = "2.14"
 itertools = "0.15"
 libsecp256k1 = "0.7.2"
 litesvm = { path = "crates/litesvm", version = "0.16" }
+litesvm-persistence = { path = "crates/persistence", version = "0.16" }
 log = "0.4"
 napi = { version = "3.12.2", default-features = false }
 napi-build = "2.4.1"

--- a/crates/node-litesvm/CHANGELOG.md
+++ b/crates/node-litesvm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `toBytes`, `fromBytes`, `saveToFile` and `loadFromFile` to snapshot the full LiteSVM state and restore it into a new instance, backed by the `litesvm-persistence` crate.
+
 ## [1.4.1] - 2026-08-25
 
 ### Fixed

--- a/crates/node-litesvm/CHANGELOG.md
+++ b/crates/node-litesvm/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add `toBytes`, `fromBytes`, `saveToFile` and `loadFromFile` to snapshot the full LiteSVM state and restore it into a new instance, backed by the `litesvm-persistence` crate.
+- Add `toBytes`, `fromBytes`, `saveToFile` and `loadFromFile` to snapshot the full LiteSVM state and restore it into a new instance, backed by the `litesvm-persistence` crate [(#420)](https://github.com/LiteSVM/litesvm/pull/420).
 
 ## [1.4.1] - 2026-08-25
 

--- a/crates/node-litesvm/Cargo.toml
+++ b/crates/node-litesvm/Cargo.toml
@@ -19,6 +19,7 @@ test = false
 agave-feature-set.workspace = true
 bv.workspace = true
 litesvm = { workspace = true, features = ["nodejs-internal", "precompiles"] }
+litesvm-persistence.workspace = true
 napi = { workspace = true, features = ["napi4", "napi6"] }
 napi-derive.workspace = true
 solana-account.workspace = true

--- a/crates/node-litesvm/docs/tutorial.md
+++ b/crates/node-litesvm/docs/tutorial.md
@@ -52,6 +52,19 @@ and passes it to LiteSVM:
 
 <<< @/../no-ci-tests/copyAccounts.test.ts
 
+## Snapshots
+
+Setting up an environment (deploying programs, minting tokens, seeding accounts)
+can dominate the runtime of a test suite. `toBytes` and `saveToFile` capture the
+full state of a `LiteSVM` instance, including accounts, sysvars, the feature set
+and the transaction history, and `fromBytes` and `loadFromFile` restore that
+state into a fresh instance:
+
+<<< @/../tests/snapshot.test.ts
+
+Snapshots use the same format as the `litesvm-persistence` Rust crate, so a
+file written from Rust can be loaded from JavaScript and vice versa.
+
 ## Other features
 
 Other things you can do with `litesvm` include:

--- a/crates/node-litesvm/litesvm/index.ts
+++ b/crates/node-litesvm/litesvm/index.ts
@@ -108,6 +108,46 @@ export class LiteSVM {
 	}
 
 	/**
+	 * Restore a LiteSVM instance from a snapshot file written by {@link saveToFile}.
+	 * @param path - The path of the snapshot file
+	 * @returns A new LiteSVM instance with the saved state
+	 */
+	static loadFromFile(path: string): LiteSVM {
+		const svm = new LiteSVM();
+		svm.inner = LiteSVMInner.loadFromFile(path);
+		return svm;
+	}
+
+	/**
+	 * Restore a LiteSVM instance from snapshot bytes produced by {@link toBytes}.
+	 * @param bytes - The snapshot bytes
+	 * @returns A new LiteSVM instance with the saved state
+	 */
+	static fromBytes(bytes: Uint8Array): LiteSVM {
+		const svm = new LiteSVM();
+		svm.inner = LiteSVMInner.fromBytes(bytes);
+		return svm;
+	}
+
+	/**
+	 * Save the full state (accounts, sysvars, feature set, transaction history)
+	 * to a file. Restore it with {@link LiteSVM.loadFromFile}.
+	 * @param path - The path to write the snapshot to
+	 */
+	saveToFile(path: string) {
+		this.inner.saveToFile(path);
+	}
+
+	/**
+	 * Serialize the full state (accounts, sysvars, feature set, transaction history)
+	 * to bytes. Restore it with {@link LiteSVM.fromBytes}.
+	 * @returns The snapshot bytes
+	 */
+	toBytes(): Uint8Array {
+		return this.inner.toBytes();
+	}
+
+	/**
 	 * Set the compute budget
 	 * @param budget - The new compute budget
 	 * @returns The modified LiteSVM instance

--- a/crates/node-litesvm/litesvm/internal.d.ts
+++ b/crates/node-litesvm/litesvm/internal.d.ts
@@ -277,6 +277,14 @@ export declare class LiteSvm {
   /** Creates the basic test environment. */
   constructor()
   static default(): LiteSvm
+  /** Restores an instance from a snapshot file written by `saveToFile`. */
+  static loadFromFile(path: string): LiteSvm
+  /** Restores an instance from snapshot bytes produced by `toBytes`. */
+  static fromBytes(bytes: Uint8Array): LiteSvm
+  /** Saves the full state (accounts, sysvars, feature set, transaction history) to a file. */
+  saveToFile(path: string): void
+  /** Serializes the full state (accounts, sysvars, feature set, transaction history) to bytes. */
+  toBytes(): Uint8Array
   setComputeBudget(budget: ComputeBudget): void
   /** Enables or disables sigverify */
   setSigverify(sigverify: boolean): void

--- a/crates/node-litesvm/src/lib.rs
+++ b/crates/node-litesvm/src/lib.rs
@@ -29,6 +29,7 @@ use {
         },
         LiteSVM as LiteSVMOriginal,
     },
+    litesvm_persistence::PersistenceError,
     napi::bindgen_prelude::*,
     solana_clock::Clock as ClockOriginal,
     solana_epoch_rewards::EpochRewards as EpochRewardsOriginal,
@@ -56,6 +57,10 @@ mod util;
 extern crate napi_derive;
 
 fn to_js_error(e: LiteSVMError, msg: &str) -> Error {
+    Error::new(Status::GenericFailure, format!("{msg}: {e}"))
+}
+
+fn persistence_error(e: PersistenceError, msg: &str) -> Error {
     Error::new(Status::GenericFailure, format!("{msg}: {e}"))
 }
 
@@ -105,6 +110,37 @@ impl LiteSvm {
     #[napi(factory, js_name = "default")]
     pub fn new_default() -> Self {
         Self(LiteSVMOriginal::default())
+    }
+
+    #[napi(factory)]
+    /// Restores an instance from a snapshot file written by `saveToFile`.
+    pub fn load_from_file(path: String) -> Result<Self> {
+        litesvm_persistence::load_from_file(path)
+            .map(Self)
+            .map_err(|e| persistence_error(e, "Failed to load snapshot"))
+    }
+
+    #[napi(factory)]
+    /// Restores an instance from snapshot bytes produced by `toBytes`.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        litesvm_persistence::from_bytes(bytes)
+            .map(Self)
+            .map_err(|e| persistence_error(e, "Failed to load snapshot"))
+    }
+
+    #[napi]
+    /// Saves the full state (accounts, sysvars, feature set, transaction history) to a file.
+    pub fn save_to_file(&self, path: String) -> Result<()> {
+        litesvm_persistence::save_to_file(&self.0, path)
+            .map_err(|e| persistence_error(e, "Failed to save snapshot"))
+    }
+
+    #[napi]
+    /// Serializes the full state (accounts, sysvars, feature set, transaction history) to bytes.
+    pub fn to_bytes(&self) -> Result<Uint8Array> {
+        litesvm_persistence::to_bytes(&self.0)
+            .map(Uint8Array::from)
+            .map_err(|e| persistence_error(e, "Failed to serialize snapshot"))
     }
 
     #[napi]

--- a/crates/node-litesvm/tests/snapshot.test.ts
+++ b/crates/node-litesvm/tests/snapshot.test.ts
@@ -1,0 +1,126 @@
+import { getTransferSolInstruction } from "@solana-program/system";
+import {
+	assertAccountExists,
+	decodeAccount,
+	generateKeyPairSigner,
+	getSignatureFromTransaction,
+	lamports,
+} from "@solana/kit";
+import { LiteSVM } from "litesvm";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+	generateAddress,
+	getCounterDecoder,
+	getGreetInstruction,
+	getSignedTransaction,
+	LAMPORTS_PER_SOL,
+	setHelloWorldAccount,
+	setHelloWorldProgram,
+} from "./util";
+
+// Deploys the counter program, seeds a payer and a counter account, and
+// records one transaction so that every part of the state is exercised.
+async function setUpEnvironment() {
+	const [payer, programAddress, greetedAddress] = await Promise.all([
+		generateKeyPairSigner(),
+		generateAddress(),
+		generateAddress(),
+	]);
+	const svm = new LiteSVM();
+	svm.airdrop(payer.address, lamports(LAMPORTS_PER_SOL));
+	setHelloWorldProgram(svm, programAddress);
+	setHelloWorldAccount(svm, greetedAddress, programAddress);
+	const transaction = await getSignedTransaction(svm, payer, [
+		getGreetInstruction(greetedAddress, programAddress),
+	]);
+	svm.sendTransaction(transaction);
+	const signature = getSignatureFromTransaction(transaction);
+	return { svm, payer, programAddress, greetedAddress, signature };
+}
+
+function getCount(svm: LiteSVM, address: Parameters<LiteSVM["getAccount"]>[0]) {
+	const account = decodeAccount(svm.getAccount(address), getCounterDecoder());
+	assertAccountExists(account);
+	return account.data.count;
+}
+
+test("snapshot round trip through bytes", async () => {
+	// Given an environment with a program, some accounts and one transaction.
+	const { svm, payer, programAddress, greetedAddress, signature } =
+		await setUpEnvironment();
+
+	// When we snapshot it and restore the snapshot into a new instance.
+	const restored = LiteSVM.fromBytes(svm.toBytes());
+
+	// Then the restored instance has the same accounts, blockhash and history.
+	assert.strictEqual(getCount(restored, greetedAddress), 1);
+	assert.strictEqual(
+		restored.getBalance(payer.address),
+		svm.getBalance(payer.address),
+	);
+	assert.strictEqual(restored.latestBlockhash(), svm.latestBlockhash());
+	assert.notStrictEqual(restored.getTransaction(signature), null);
+
+	// And the program deployed before the snapshot still runs. The blockhash
+	// is expired first so the new transaction does not collide with the one
+	// already in the restored history.
+	restored.expireBlockhash();
+	const transaction = await getSignedTransaction(restored, payer, [
+		getGreetInstruction(greetedAddress, programAddress),
+	]);
+	restored.sendTransaction(transaction);
+	assert.strictEqual(getCount(restored, greetedAddress), 2);
+});
+
+test("snapshot round trip through a file", async () => {
+	const { svm, greetedAddress } = await setUpEnvironment();
+	const dir = mkdtempSync(join(tmpdir(), "litesvm-snapshot-"));
+	try {
+		const path = join(dir, "state.bin");
+		svm.saveToFile(path);
+		const restored = LiteSVM.loadFromFile(path);
+		assert.strictEqual(getCount(restored, greetedAddress), 1);
+		assert.strictEqual(restored.latestBlockhash(), svm.latestBlockhash());
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("restored instances are independent", async () => {
+	// Given a snapshot restored twice, as a test suite would before each test.
+	const { svm, payer } = await setUpEnvironment();
+	const snapshot = svm.toBytes();
+	const [first, second] = [
+		LiteSVM.fromBytes(snapshot),
+		LiteSVM.fromBytes(snapshot),
+	];
+	const balanceBefore = svm.getBalance(payer.address);
+
+	// When we spend from one of the restored instances.
+	const receiver = await generateAddress();
+	const transaction = await getSignedTransaction(first, payer, [
+		getTransferSolInstruction({
+			source: payer,
+			destination: receiver,
+			amount: lamports(1_000_000n),
+		}),
+	]);
+	first.sendTransaction(transaction);
+
+	// Then neither the original nor the other restored instance is affected.
+	assert.strictEqual(first.getBalance(receiver), lamports(1_000_000n));
+	assert.strictEqual(second.getBalance(receiver), null);
+	assert.strictEqual(svm.getBalance(receiver), null);
+	assert.strictEqual(second.getBalance(payer.address), balanceBefore);
+});
+
+test("fromBytes rejects data that is not a snapshot", () => {
+	assert.throws(
+		() => LiteSVM.fromBytes(new Uint8Array([255, 1, 2, 3])),
+		/Failed to load snapshot/,
+	);
+});


### PR DESCRIPTION
Closes #350.

Exposes the `litesvm-persistence` crate through the Node bindings so a fully set up environment can be snapshotted once and restored before each test:

- `toBytes()` / `LiteSVM.fromBytes(bytes)` for in-memory snapshots.
- `saveToFile(path)` / `LiteSVM.loadFromFile(path)` for on-disk snapshots.

The snapshot covers everything the Rust crate covers (accounts, sysvars, feature set, transaction history, compute budget, fee structure, blockhash) and uses the same format, so a file written from Rust loads from JavaScript and vice versa. Names follow the Rust functions rather than the `toBuffer`/`fromBuffer` suggested in the issue, since the JS package returns `Uint8Array` everywhere else.

Tests cover the bytes and file round trips, that a program deployed before the snapshot still runs after restore, that instances restored from the same snapshot are independent, and that invalid input throws. Added a short section to the tutorial and a changelog entry.
